### PR TITLE
run ngOnDestroy for service after every test

### DIFF
--- a/projects/spectator/src/lib/service.ts
+++ b/projects/spectator/src/lib/service.ts
@@ -42,6 +42,13 @@ export function createService<S>(options: Params<S> | Type<S>): SpectatorService
     TestBed.configureTestingModule(module);
   });
 
+  afterEach(() => {
+    const testedService = TestBed.get(service);
+    if (typeof testedService.ngOnDestroy === 'function') {
+      testedService.ngOnDestroy();
+    }
+  });
+
   return {
     get service(): S {
       return TestBed.get(service);

--- a/src/app/ng-on-destroy.service.spec.ts
+++ b/src/app/ng-on-destroy.service.spec.ts
@@ -1,0 +1,36 @@
+import { NgOnDestroyService, ngOnDestroySpy } from './ng-on-destroy.service';
+import { SubjectService } from './subject.service';
+import { createService } from '@netbasal/spectator';
+import { mockProvider } from '@netbasal/spectator/jest';
+import { Subject } from 'rxjs';
+
+describe('NgOnDestroyService', () => {
+  const spyAcrossMultipleTests = jasmine.createSpy('ngOnDestroy test spy');
+  const subjectAcrossMultipleTests$ = new Subject();
+  const spectator = createService({
+    service: NgOnDestroyService,
+    providers: [
+      {
+        provide: ngOnDestroySpy,
+        useValue: spyAcrossMultipleTests
+      },
+      mockProvider(SubjectService, {
+        subject$: subjectAcrossMultipleTests$
+      })
+    ]
+  });
+
+  /**
+   * !! The order of tests depends here !!
+   */
+  it('should subscribe to subject during', () => {
+    const service: NgOnDestroyService = spectator.service;
+    expect(service).toBeTruthy();
+    expect(subjectAcrossMultipleTests$.observers.length).toBe(1);
+  });
+
+  it('should call spy only once on because previous were unsubscribe in ngOnDestroy', () => {
+    const service: NgOnDestroyService = spectator.service;
+    expect(subjectAcrossMultipleTests$.observers.length).toBe(1);
+  });
+});

--- a/src/app/ng-on-destroy.service.spec.ts
+++ b/src/app/ng-on-destroy.service.spec.ts
@@ -1,19 +1,14 @@
-import { NgOnDestroyService, ngOnDestroySpy } from './ng-on-destroy.service';
+import { NgOnDestroyService } from './ng-on-destroy.service';
 import { SubjectService } from './subject.service';
 import { createService } from '@netbasal/spectator';
 import { mockProvider } from '@netbasal/spectator/jest';
 import { Subject } from 'rxjs';
 
 describe('NgOnDestroyService', () => {
-  const spyAcrossMultipleTests = jasmine.createSpy('ngOnDestroy test spy');
   const subjectAcrossMultipleTests$ = new Subject();
   const spectator = createService({
     service: NgOnDestroyService,
     providers: [
-      {
-        provide: ngOnDestroySpy,
-        useValue: spyAcrossMultipleTests
-      },
       mockProvider(SubjectService, {
         subject$: subjectAcrossMultipleTests$
       })

--- a/src/app/ng-on-destroy.service.ts
+++ b/src/app/ng-on-destroy.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, OnDestroy, Inject, InjectionToken } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { SubjectService } from './subject.service';
+
+export const ngOnDestroySpy = new InjectionToken('ngOnDestroy Spy');
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NgOnDestroyService implements OnDestroy {
+  subscription: Subscription;
+
+  constructor(private subjectService: SubjectService, @Inject(ngOnDestroySpy) private spy: jasmine.Spy) {
+    this.subscription = this.subjectService.subject$.subscribe(() => {
+      this.spy();
+    });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/app/ng-on-destroy.service.ts
+++ b/src/app/ng-on-destroy.service.ts
@@ -1,8 +1,6 @@
-import { Injectable, OnDestroy, Inject, InjectionToken } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SubjectService } from './subject.service';
-
-export const ngOnDestroySpy = new InjectionToken('ngOnDestroy Spy');
 
 @Injectable({
   providedIn: 'root'
@@ -10,10 +8,8 @@ export const ngOnDestroySpy = new InjectionToken('ngOnDestroy Spy');
 export class NgOnDestroyService implements OnDestroy {
   subscription: Subscription;
 
-  constructor(private subjectService: SubjectService, @Inject(ngOnDestroySpy) private spy: jasmine.Spy) {
-    this.subscription = this.subjectService.subject$.subscribe(() => {
-      this.spy();
-    });
+  constructor(private subjectService: SubjectService) {
+    this.subscription = this.subjectService.subject$.subscribe();
   }
 
   ngOnDestroy() {

--- a/src/app/subject.service.spec.ts
+++ b/src/app/subject.service.spec.ts
@@ -1,0 +1,13 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SubjectService } from './subject.service';
+import { createService } from '@netbasal/spectator';
+
+describe('SubjectService', () => {
+  const spectator = createService(SubjectService);
+
+  it('should be created', () => {
+    const service: SubjectService = spectator.service;
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/subject.service.ts
+++ b/src/app/subject.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SubjectService {
+  subject$ = new Subject();
+
+  constructor() {}
+}


### PR DESCRIPTION
Fixes https://github.com/NetanelBasal/spectator/issues/92

I tried to simulate the tests exactly like it happened to us. Part of the problem is also that a single subject is used across multiple tests (could be issue with `ReplaySubject` for example). If it created a new subject every time it would cause only memory leak :-)

Also this sort of black-box-testing depends on the order of tests. General approach is to randomise test execution order. Then this test would not be reliable.