### PR TITLE
refactor: change NPM scope from @netbasal to @ngneat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Then, in the root of your consuming app,
 Tell `npm` to link to the package:
 
 ```
-npm link @netbasal/spectator
+npm link @ngneat/spectator
 ```
 
 Run tests while preserving symlinks:

--- a/projects/spectator/jest.config.js
+++ b/projects/spectator/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
   testMatch: ['**/jest/**/*.spec.ts'],
   setupFilesAfterEnv: ['<rootDir>/projects/spectator/setup-jest.ts'],
   moduleNameMapper: {
-    '@netbasal/spectator/jest': '<rootDir>/projects/spectator/jest/src/public_api.ts',
-    '@netbasal/spectator': '<rootDir>/projects/spectator/src/public_api.ts'
+    '@ngneat/spectator/jest': '<rootDir>/projects/spectator/jest/src/public_api.ts',
+    '@ngneat/spectator': '<rootDir>/projects/spectator/src/public_api.ts'
   }
 };

--- a/projects/spectator/jest/src/lib/dom-selectors.ts
+++ b/projects/spectator/jest/src/lib/dom-selectors.ts
@@ -1,1 +1,1 @@
-export { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, byTestId } from '@netbasal/spectator';
+export { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, byTestId } from '@ngneat/spectator';

--- a/projects/spectator/jest/src/lib/http.ts
+++ b/projects/spectator/jest/src/lib/http.ts
@@ -1,5 +1,5 @@
 import { FactoryProvider, Type } from '@angular/core';
-import { createHTTPFactory as baseCreateHTTPFactory, SpectatorHTTP } from '@netbasal/spectator';
+import { createHTTPFactory as baseCreateHTTPFactory, SpectatorHTTP } from '@ngneat/spectator';
 
 /**
  * @deprecated Deprecated in favour of createHttpFactory

--- a/projects/spectator/jest/src/lib/mock.ts
+++ b/projects/spectator/jest/src/lib/mock.ts
@@ -1,5 +1,5 @@
 import { FactoryProvider, Type } from '@angular/core';
-import { installProtoMethods, CompatibleSpy, SpyObject as BaseSpyObject } from '@netbasal/spectator';
+import { installProtoMethods, CompatibleSpy, SpyObject as BaseSpyObject } from '@ngneat/spectator';
 
 export type SpyObject<T> = BaseSpyObject<T> & { [P in keyof T]: T[P] & (T[P] extends (...args: any[]) => infer R ? jest.Mock<R> : T[P]) };
 

--- a/projects/spectator/jest/src/lib/spectator-directive.ts
+++ b/projects/spectator/jest/src/lib/spectator-directive.ts
@@ -7,7 +7,7 @@ import {
   SpectatorDirectiveOptions,
   SpectatorDirectiveOverrides,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/src/lib/spectator-host.ts
+++ b/projects/spectator/jest/src/lib/spectator-host.ts
@@ -7,7 +7,7 @@ import {
   SpectatorHostOptions,
   SpectatorHostOverrides,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/src/lib/spectator-http.ts
+++ b/projects/spectator/jest/src/lib/spectator-http.ts
@@ -7,7 +7,7 @@ import {
   SpectatorHttp as BaseSpectatorHttp,
   SpectatorHttpOptions,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/src/lib/spectator-routing.ts
+++ b/projects/spectator/jest/src/lib/spectator-routing.ts
@@ -6,7 +6,7 @@ import {
   SpectatorRoutingOptions,
   SpectatorRoutingOverrides,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/src/lib/spectator-service.ts
+++ b/projects/spectator/jest/src/lib/spectator-service.ts
@@ -7,7 +7,7 @@ import {
   SpectatorServiceOptions,
   SpectatorService as BaseSpectatorService,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/src/lib/spectator.ts
+++ b/projects/spectator/jest/src/lib/spectator.ts
@@ -6,7 +6,7 @@ import {
   SpectatorFactory,
   SpectatorOptions,
   Token
-} from '@netbasal/spectator';
+} from '@ngneat/spectator';
 
 import { mockProvider, SpyObject } from './mock';
 

--- a/projects/spectator/jest/test/async-input/async-input.component.spec.ts
+++ b/projects/spectator/jest/test/async-input/async-input.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { fakeAsync, tick } from '@angular/core/testing';
 
 import { AsyncInputComponent } from '../../../test/async-input/async-input.component';

--- a/projects/spectator/jest/test/async/async.component.spec.ts
+++ b/projects/spectator/jest/test/async/async.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { AsyncComponent } from '../../../test/async/async.component';
 import { QueryService } from '../../../test/query.service';

--- a/projects/spectator/jest/test/auth.service.spec.ts
+++ b/projects/spectator/jest/test/auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService } from '@netbasal/spectator/jest';
+import { createService } from '@ngneat/spectator/jest';
 
 import { AuthService } from '../../test/auth.service';
 import { DateService } from '../../test/date.service';

--- a/projects/spectator/jest/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/jest/test/auto-focus.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { SpectatorHost, createHostFactory, createDirectiveFactory, SpectatorDirective } from '@netbasal/spectator/jest';
+import { SpectatorHost, createHostFactory, createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator/jest';
 
 import { AutoFocusDirective } from '../../test/auto-focus.directive';
 

--- a/projects/spectator/jest/test/button/button.component.spec.ts
+++ b/projects/spectator/jest/test/button/button.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, mockProvider, Spectator } from '@netbasal/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { ButtonComponent } from '../../../test/button/button.component';

--- a/projects/spectator/jest/test/calc.component.jest.ts
+++ b/projects/spectator/jest/test/calc.component.jest.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, Spectator } from '@netbasal/spectator/jest';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 
 import { CalcComponent } from './calc.component';
 

--- a/projects/spectator/jest/test/consum-dynamic/consume-dynamic.component.spec.ts
+++ b/projects/spectator/jest/test/consum-dynamic/consume-dynamic.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { ConsumeDynamicComponent } from '../../../test/consum-dynamic/consume-dynamic.component';
 import { DynamicComponent } from '../../../test/dynamic/dynamic.component';

--- a/projects/spectator/jest/test/consumer.service.spec.ts
+++ b/projects/spectator/jest/test/consumer.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService, mockProvider } from '@netbasal/spectator/jest';
+import { createService, mockProvider } from '@ngneat/spectator/jest';
 import { Subject } from 'rxjs';
 
 import { ConsumerService } from '../../test/consumer.service';

--- a/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, Spectator, byAltText, byLabel, byPlaceholder, byText, byTitle, byValue } from '@netbasal/spectator/jest';
+import { createComponentFactory, Spectator, byAltText, byLabel, byPlaceholder, byText, byTitle, byValue } from '@ngneat/spectator/jest';
 
 import { DomSelectorsComponent } from '../../../test/dom-selectors/dom-selectors.component';
 

--- a/projects/spectator/jest/test/fg/fg.component.spec.ts
+++ b/projects/spectator/jest/test/fg/fg.component.spec.ts
@@ -1,4 +1,4 @@
-import { SpectatorHost, createHostFactory } from '@netbasal/spectator/jest';
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator/jest';
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 

--- a/projects/spectator/jest/test/form-input/form-input.component.spec.ts
+++ b/projects/spectator/jest/test/form-input/form-input.component.spec.ts
@@ -1,5 +1,5 @@
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { createHostFactory, SpectatorHost, Spectator, createComponentFactory } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 
 import { FormInputComponent } from '../../../test/form-input/form-input.component';
 

--- a/projects/spectator/jest/test/hello/hello.component.spec.ts
+++ b/projects/spectator/jest/test/hello/hello.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { HelloComponent } from '../../../test/hello/hello.component';
 

--- a/projects/spectator/jest/test/highlight.directive.spec.ts
+++ b/projects/spectator/jest/test/highlight.directive.spec.ts
@@ -1,5 +1,5 @@
-import { createDirectiveFactory, SpectatorDirective, SpectatorHost } from '@netbasal/spectator';
-import { createHostFactory } from '@netbasal/spectator/jest';
+import { createDirectiveFactory, SpectatorDirective, SpectatorHost } from '@ngneat/spectator';
+import { createHostFactory } from '@ngneat/spectator/jest';
 
 import { HighlightDirective } from '../../test/highlight.directive';
 

--- a/projects/spectator/jest/test/injection-and-mocking.spec.ts
+++ b/projects/spectator/jest/test/injection-and-mocking.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, createService, createComponentFactory, Spectator } from '@netbasal/spectator/jest';
+import { createHostFactory, createService, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { InjectionToken } from '@angular/core';
 
 import { ConsumerService } from '../../test/consumer.service';

--- a/projects/spectator/jest/test/no-overwritten-providers/no-overwritten-providers.component.spec.ts
+++ b/projects/spectator/jest/test/no-overwritten-providers/no-overwritten-providers.component.spec.ts
@@ -1,5 +1,5 @@
-import { createHostFactory } from '@netbasal/spectator/jest';
-import { mockProvider } from '@netbasal/spectator';
+import { createHostFactory } from '@ngneat/spectator/jest';
+import { mockProvider } from '@ngneat/spectator';
 
 import { ComponentWithoutOverwrittenProvidersComponent } from '../../../test/no-overwritten-providers/no-overwritten-providers.component';
 import { DummyService } from '../../../test/no-overwritten-providers/dummy.service';

--- a/projects/spectator/jest/test/spy-object/spy-object.spec.ts
+++ b/projects/spectator/jest/test/spy-object/spy-object.spec.ts
@@ -1,4 +1,4 @@
-import { createSpyObject } from '@netbasal/spectator/jest';
+import { createSpyObject } from '@ngneat/spectator/jest';
 
 import { Person } from '../../../test/spy-object/person';
 

--- a/projects/spectator/jest/test/todos-data-old.service.spec.ts
+++ b/projects/spectator/jest/test/todos-data-old.service.spec.ts
@@ -1,7 +1,7 @@
 import { fakeAsync, tick } from '@angular/core/testing';
 import { defer } from 'rxjs';
-import { HTTPMethod } from '@netbasal/spectator';
-import { createHTTPFactory, mockProvider, SpyObject } from '@netbasal/spectator/jest';
+import { HTTPMethod } from '@ngneat/spectator';
+import { createHTTPFactory, mockProvider, SpyObject } from '@ngneat/spectator/jest';
 
 import { TodosDataService, UserService } from '../../test/todos-data.service';
 

--- a/projects/spectator/jest/test/todos-data.service.spec.ts
+++ b/projects/spectator/jest/test/todos-data.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createHttpFactory, HttpMethod } from '@netbasal/spectator/jest';
+import { createHttpFactory, HttpMethod } from '@ngneat/spectator/jest';
 import { defer } from 'rxjs';
 
 import { TodosDataService, UserService } from '../../test/todos-data.service';

--- a/projects/spectator/jest/test/unless/unless.component.spec.ts
+++ b/projects/spectator/jest/test/unless/unless.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { AppUnlessDirective } from '../../../test/unless/unless.component';
 

--- a/projects/spectator/jest/test/view-children/view-children.component.spec.ts
+++ b/projects/spectator/jest/test/view-children/view-children.component.spec.ts
@@ -1,5 +1,5 @@
 import { ElementRef } from '@angular/core';
-import { createHostFactory, createComponentFactory, Spectator, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, createComponentFactory, Spectator, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { ViewChildrenComponent } from '../../../test/view-children/view-children.component';
 import { ChildServiceService } from '../../../test/child-service.service';

--- a/projects/spectator/jest/test/widget.service.spec.ts
+++ b/projects/spectator/jest/test/widget.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService } from '@netbasal/spectator/jest';
+import { createService } from '@ngneat/spectator/jest';
 
 import { WidgetDataService } from '../../test/widget-data.service';
 import { WidgetService } from '../../test/widget.service';

--- a/projects/spectator/jest/test/widget/widget.component.spec.ts
+++ b/projects/spectator/jest/test/widget/widget.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { WidgetComponent } from '../../../test/widget/widget.component';
 import { WidgetService } from '../../../test/widget.service';

--- a/projects/spectator/jest/test/with-routing/my-page.component.spec.ts
+++ b/projects/spectator/jest/test/with-routing/my-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { Router, RouterLink } from '@angular/router';
-import { createRoutingFactory } from '@netbasal/spectator/jest';
+import { createRoutingFactory } from '@ngneat/spectator/jest';
 
 import { MyPageComponent } from '../../../test/with-routing/my-page.component';
 

--- a/projects/spectator/jest/test/zippy/zippy.component.spec.ts
+++ b/projects/spectator/jest/test/zippy/zippy.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createHostFactory, SpectatorHost } from '@netbasal/spectator/jest';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
 import { ZippyComponent } from '../../../test/zippy/zippy.component';
 import { QueryService } from '../../../test/query.service';

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@netbasal/spectator",
+  "name": "@ngneat/spectator",
   "description": "Angular tests made easy",
   "author": "Netanel Basal <netanel7799s@gmail.com>",
   "version": "3.12.0",

--- a/projects/spectator/schematics/src/collection.json
+++ b/projects/spectator/schematics/src/collection.json
@@ -3,7 +3,7 @@
   "extends": ["@schematics/angular"],
   "schematics": {
     "ng-add": {
-      "description": "Install the @netbasal/spectator library",
+      "description": "Install the @ngneat/spectator library",
       "factory": "./ng-add/index",
       "schema": "./ng-add/schema.json"
     },

--- a/projects/spectator/schematics/src/ng-add/index.js
+++ b/projects/spectator/schematics/src/ng-add/index.js
@@ -5,7 +5,7 @@ const tasks_1 = require("@angular-devkit/schematics/tasks");
 const schematics_utilities_1 = require("schematics-utilities");
 function addPackageJsonDependencies() {
     return (host, context) => {
-        const dependencies = [{ type: schematics_utilities_1.NodeDependencyType.Dev, version: '~3.2.1', name: '@netbasal/spectator' }];
+        const dependencies = [{ type: schematics_utilities_1.NodeDependencyType.Dev, version: '~3.2.1', name: '@ngneat/spectator' }];
         dependencies.forEach(dependency => {
             schematics_utilities_1.addPackageJsonDependency(host, dependency);
             context.logger.info(`✅️ Added "${dependency.name}" into ${dependency.type}`);

--- a/projects/spectator/schematics/src/ng-add/index.ts
+++ b/projects/spectator/schematics/src/ng-add/index.ts
@@ -6,7 +6,7 @@ import { Schema } from './schema';
 
 function addPackageJsonDependencies(): Rule {
   return (host: Tree, context: SchematicContext) => {
-    const dependencies: NodeDependency[] = [{ type: NodeDependencyType.Dev, version: '~3.2.1', name: '@netbasal/spectator' }];
+    const dependencies: NodeDependency[] = [{ type: NodeDependencyType.Dev, version: '~3.2.1', name: '@ngneat/spectator' }];
 
     dependencies.forEach(dependency => {
       addPackageJsonDependency(host, dependency);
@@ -29,12 +29,18 @@ function installPackageJsonDependencies(): Rule {
 function showGreeting(): Rule {
   return (host: Tree, context: SchematicContext) => {
     context.logger.info('👏 Create your first spectator test by checkout docs: https://netbasal.gitbook.io/spectator/');
-    context.logger.info('🙀 Last but Not Least, Have you Heard of Akita? https://netbasal.com/introducing-akita-a-new-state-management-pattern-for-angular-applications-f2f0fab5a8');
+    context.logger.info(
+      '🙀 Last but Not Least, Have you Heard of Akita? https://netbasal.com/introducing-akita-a-new-state-management-pattern-for-angular-applications-f2f0fab5a8'
+    );
 
     return host;
   };
 }
 
 export default function(options: Schema): Rule {
-  return chain([options && options.skipPackageJson ? noop() : addPackageJsonDependencies(), options && options.skipInstall ? noop() : installPackageJsonDependencies(), options && options.skipGreeting ? noop() : showGreeting()]);
+  return chain([
+    options && options.skipPackageJson ? noop() : addPackageJsonDependencies(),
+    options && options.skipInstall ? noop() : installPackageJsonDependencies(),
+    options && options.skipGreeting ? noop() : showGreeting()
+  ]);
 }

--- a/projects/spectator/schematics/src/ng-add/schema.json
+++ b/projects/spectator/schematics/src/ng-add/schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "SchematicsNetbasalSpectatorNgAdd",
-  "title": "Install the @netbasal/spectator library options schema",
+  "title": "Install the @ngneat/spectator library options schema",
   "type": "object",
-  "description": "Adds @netbasal/spectator in the package.json file and runs install dependencies.",
+  "description": "Adds @ngneat/spectator in the package.json file and runs install dependencies.",
   "properties": {
     "skipPackageJson": {
       "description": "When true, does not add dependencies to the \"package.json\" file.",

--- a/projects/spectator/schematics/src/spectator/files/component-custom-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-custom-host/__name@dasherize__.component.spec.ts
@@ -1,5 +1,5 @@
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
-import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostComponentFactory, SpectatorWithHost } from '@ngneat/spectator';
 import { Component } from '@angular/core';
 
 @Component({ selector: 'custom-host', template: '' })

--- a/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
@@ -1,5 +1,5 @@
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
-import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostComponentFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 describe('<%= classify(name)%>Component', () => {
   let host: SpectatorWithHost<<%= classify(name)%>Component>;

--- a/projects/spectator/schematics/src/spectator/files/component/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component/__name@dasherize__.component.spec.ts
@@ -1,5 +1,5 @@
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
-import { Spectator, createTestComponentFactory } from '@netbasal/spectator';
+import { Spectator, createTestComponentFactory } from '@ngneat/spectator';
 
 describe('<%= classify(name)%>Component', () => {
   let spectator: Spectator<<%= classify(name)%>Component>;

--- a/projects/spectator/schematics/src/spectator/files/directive/__name@dasherize__.directive.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/directive/__name@dasherize__.directive.spec.ts
@@ -1,5 +1,5 @@
 import { <%= classify(name)%>Directive } from './<%= dasherize(name)%>.directive';
-import { createHostComponentFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostComponentFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 describe('<%= classify(name)%>Directive ', () => {
   let host: SpectatorWithHost<<%= classify(name)%>Directive>;

--- a/projects/spectator/test/async-input/async-input.component.spec.ts
+++ b/projects/spectator/test/async-input/async-input.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 import { fakeAsync, tick } from '@angular/core/testing';
 
 import { AsyncInputComponent } from './async-input.component';

--- a/projects/spectator/test/async/async.component.spec.ts
+++ b/projects/spectator/test/async/async.component.spec.ts
@@ -1,5 +1,5 @@
 import { of } from 'rxjs';
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { QueryService } from '../query.service';
 

--- a/projects/spectator/test/auth.service.spec.ts
+++ b/projects/spectator/test/auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService } from '@netbasal/spectator';
+import { createService } from '@ngneat/spectator';
 
 import { AuthService } from './auth.service';
 import { DateService } from './date.service';

--- a/projects/spectator/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/test/auto-focus.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { createHostFactory, createDirectiveFactory, SpectatorDirective, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, createDirectiveFactory, SpectatorDirective, SpectatorWithHost } from '@ngneat/spectator';
 
 import { AutoFocusDirective } from './auto-focus.directive';
 

--- a/projects/spectator/test/button/button.component.spec.ts
+++ b/projects/spectator/test/button/button.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, mockProvider, Spectator } from '@netbasal/spectator';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
 import { QueryService } from '../query.service';

--- a/projects/spectator/test/calc/calc.component.spec.ts
+++ b/projects/spectator/test/calc/calc.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, Spectator } from '@netbasal/spectator';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
 import { CalcComponent } from './calc.component';
 

--- a/projects/spectator/test/consum-dynamic/consume-dynamic.component.spec.ts
+++ b/projects/spectator/test/consum-dynamic/consume-dynamic.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { DynamicComponent } from '../dynamic/dynamic.component';
 

--- a/projects/spectator/test/consumer.service.spec.ts
+++ b/projects/spectator/test/consumer.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService, mockProvider } from '@netbasal/spectator';
+import { createService, mockProvider } from '@ngneat/spectator';
 import { Subject } from 'rxjs';
 
 import { ConsumerService } from './consumer.service';

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
@@ -1,4 +1,4 @@
-import { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, createComponentFactory, Spectator } from '@netbasal/spectator';
+import { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, createComponentFactory, Spectator } from '@ngneat/spectator';
 
 import { DomSelectorsComponent } from './dom-selectors.component';
 

--- a/projects/spectator/test/events/events.component.spec.ts
+++ b/projects/spectator/test/events/events.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, Spectator } from '@netbasal/spectator';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
 import { EventsComponent } from './events.component';
 

--- a/projects/spectator/test/fg/fg.component.spec.ts
+++ b/projects/spectator/test/fg/fg.component.spec.ts
@@ -1,4 +1,4 @@
-import { SpectatorWithHost, createHostFactory } from '@netbasal/spectator';
+import { SpectatorWithHost, createHostFactory } from '@ngneat/spectator';
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 

--- a/projects/spectator/test/form-input/form-input.component.spec.ts
+++ b/projects/spectator/test/form-input/form-input.component.spec.ts
@@ -1,5 +1,5 @@
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { createHostFactory, SpectatorWithHost, Spectator, createComponentFactory } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost, Spectator, createComponentFactory } from '@ngneat/spectator';
 
 import { FormInputComponent } from './form-input.component';
 

--- a/projects/spectator/test/hello/hello.component.spec.ts
+++ b/projects/spectator/test/hello/hello.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { HelloComponent } from './hello.component';
 

--- a/projects/spectator/test/highlight.directive.spec.ts
+++ b/projects/spectator/test/highlight.directive.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { HighlightDirective } from './highlight.directive';
 

--- a/projects/spectator/test/injection-and-mocking.spec.ts
+++ b/projects/spectator/test/injection-and-mocking.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, createService, createComponentFactory, Spectator } from '@netbasal/spectator';
+import { createHostFactory, createService, createComponentFactory, Spectator } from '@ngneat/spectator';
 import { InjectionToken } from '@angular/core';
 
 import { ConsumerService } from './consumer.service';

--- a/projects/spectator/test/integration/integration-parent.component.spec.ts
+++ b/projects/spectator/test/integration/integration-parent.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Spectator, createComponentFactory } from '@netbasal/spectator';
+import { Spectator, createComponentFactory } from '@ngneat/spectator';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { IntegrationParentComponent } from './integration-parent.component';

--- a/projects/spectator/test/mocks.spec.ts
+++ b/projects/spectator/test/mocks.spec.ts
@@ -1,4 +1,4 @@
-import { mockProvider } from '@netbasal/spectator';
+import { mockProvider } from '@ngneat/spectator';
 
 import { WidgetService } from './widget.service';
 

--- a/projects/spectator/test/no-overwritten-providers/no-overwritten-providers.component.spec.ts
+++ b/projects/spectator/test/no-overwritten-providers/no-overwritten-providers.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, mockProvider } from '@netbasal/spectator';
+import { createHostFactory, mockProvider } from '@ngneat/spectator';
 
 import { ComponentWithoutOverwrittenProvidersComponent } from './no-overwritten-providers.component';
 import { DummyService } from './dummy.service';

--- a/projects/spectator/test/spy-object/spy-object.spec.ts
+++ b/projects/spectator/test/spy-object/spy-object.spec.ts
@@ -1,4 +1,4 @@
-import { createSpyObject } from '@netbasal/spectator';
+import { createSpyObject } from '@ngneat/spectator';
 
 import { Person } from './person';
 

--- a/projects/spectator/test/todos-data-old.service.spec.ts
+++ b/projects/spectator/test/todos-data-old.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createHTTPFactory, mockProvider, HTTPMethod, SpyObject } from '@netbasal/spectator';
+import { createHTTPFactory, mockProvider, HTTPMethod, SpyObject } from '@ngneat/spectator';
 import { defer } from 'rxjs';
 
 import { TodosDataService, UserService } from './todos-data.service';

--- a/projects/spectator/test/todos-data.service.spec.ts
+++ b/projects/spectator/test/todos-data.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createHttpFactory, HttpMethod } from '@netbasal/spectator';
+import { createHttpFactory, HttpMethod } from '@ngneat/spectator';
 import { defer } from 'rxjs';
 
 import { TodosDataService, UserService } from './todos-data.service';

--- a/projects/spectator/test/unless/unless.component.spec.ts
+++ b/projects/spectator/test/unless/unless.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { AppUnlessDirective } from './unless.component';
 

--- a/projects/spectator/test/view-children/view-children.component.spec.ts
+++ b/projects/spectator/test/view-children/view-children.component.spec.ts
@@ -1,5 +1,5 @@
 import { ElementRef } from '@angular/core';
-import { createHostFactory, createComponentFactory, Spectator, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, createComponentFactory, Spectator, SpectatorWithHost } from '@ngneat/spectator';
 
 import { ChildServiceService } from '../child-service.service';
 import { ChildComponent } from '../child/child.component';

--- a/projects/spectator/test/widget.service.spec.ts
+++ b/projects/spectator/test/widget.service.spec.ts
@@ -1,4 +1,4 @@
-import { createService } from '@netbasal/spectator';
+import { createService } from '@ngneat/spectator';
 
 import { WidgetDataService } from './widget-data.service';
 import { WidgetService } from './widget.service';

--- a/projects/spectator/test/widget/widget.component.spec.ts
+++ b/projects/spectator/test/widget/widget.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorWithHost, SpyObject } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost, SpyObject } from '@ngneat/spectator';
 
 import { WidgetService } from '../widget.service';
 

--- a/projects/spectator/test/with-routing/my-page.component.spec.ts
+++ b/projects/spectator/test/with-routing/my-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { Router, RouterLink } from '@angular/router';
-import { createRoutingFactory } from '@netbasal/spectator';
+import { createRoutingFactory } from '@ngneat/spectator';
 
 import { MyPageComponent } from './my-page.component';
 

--- a/projects/spectator/test/zippy/zippy.component.spec.ts
+++ b/projects/spectator/test/zippy/zippy.component.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createHostFactory, SpectatorWithHost } from '@netbasal/spectator';
+import { createHostFactory, SpectatorWithHost } from '@ngneat/spectator';
 
 import { QueryService } from '../query.service';
 import { CalcComponent } from '../calc/calc.component';

--- a/projects/spectator/tsconfig.spec.json
+++ b/projects/spectator/tsconfig.spec.json
@@ -8,10 +8,10 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@netbasal/spectator": [
+      "@ngneat/spectator": [
         "src/public_api.ts"
       ],
-      "@netbasal/spectator/jest": [
+      "@ngneat/spectator/jest": [
         "jest/src/public_api.ts"
       ]
     }

--- a/projects/spectator/typings/jest/index.d.ts
+++ b/projects/spectator/typings/jest/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * This file was creating to avoid conflicts during building between jasmine and jest.
  *
- * Projects using @netbasal/spectator should just use either @types/jasmine or @types/jest.
+ * Projects using @ngneat/spectator should just use either @types/jasmine or @types/jest.
  */
 
 declare namespace jest {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
       "dom"
     ],
     "paths": {
-      "@netbasal/spectator": [
+      "@ngneat/spectator": [
         "dist/spectator"
       ]
     }


### PR DESCRIPTION
The package has been moved to the ngneat organization.

BREAKING CHANGE: All imports have been changed from @netbasal/spectator to @ngneat/spectator.