### PR TITLE
fix(spectator): fix incorrect method typing

### DIFF
--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -55,7 +55,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return getChildren<R>(this.debugElement)(directiveOrSelector, options);
   }
 
-  public queryLast<R extends Element[]>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
+  public queryLast<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
   public queryLast<R>(directive: Type<R>): R | null;
   public queryLast<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
   public queryLast<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. --> 
Changed `spectator.queryLast` from `Element[]` to `Element`, because `queryLast` should return only one value.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

