### PR TITLE
fix: initial change detection before querying debug element

### DIFF
--- a/projects/spectator/src/lib/spectator-directive/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-directive/create-factory.ts
@@ -66,7 +66,7 @@ export function createDirectiveFactory<D, H = HostComponent>(
       set: { template }
     });
 
-    const spectator = createSpectatorDirective(options, props, hostProps);
+    const spectator = createSpectatorDirective(options, props, hostProps, detectChanges);
 
     if (options.detectChanges && detectChanges) {
       spectator.detectChanges();
@@ -79,9 +79,16 @@ export function createDirectiveFactory<D, H = HostComponent>(
 function createSpectatorDirective<D, H, HP>(
   options: Required<SpectatorDirectiveOptions<D, H>>,
   props?: Partial<D>,
-  hostProps?: HP
+  hostProps?: HP,
+  detectChanges?: boolean
 ): SpectatorDirective<D, H & HP> {
   const hostFixture = TestBed.createComponent(options.host);
+
+  // run an initial change detection before querying the debug node
+  if (options.detectChanges && detectChanges) {
+    hostFixture.detectChanges();
+  }
+
   const debugElement = hostFixture.debugElement.query(By.directive(options.directive)) || hostFixture.debugElement;
   const debugNode = hostFixture.debugElement.queryAllNodes(nodeByDirective(options.directive))[0];
 


### PR DESCRIPTION
This PR allows to have tests with `SpectatorHost` and `SpectatorDirective` where an inital change detection needs to run, before the component/directive is actually visible.

Example:
```ts
createComponent(`
    <mat-horizontal-stepper>
        <mat-step>
            <app-stepper-controls></app-stepper-controls>
        </mat-step>
    </mat-horizontal-stepper>
`);
```
(where `app-stepper-controls` is the component under test)

This behaviour can be overriden using the existing `detectChanges` option (not sure if that makes sense).