### PR TITLE
fix(jest/lib): template mutation with createSpyObject

### DIFF
--- a/projects/spectator/jest/src/lib/mock.ts
+++ b/projects/spectator/jest/src/lib/mock.ts
@@ -7,7 +7,7 @@ export type SpyObject<T> = BaseSpyObject<T> & { [P in keyof T]: T[P] & (T[P] ext
  * @internal
  */
 export function createSpyObject<T>(type: InjectableType<T>, template?: Partial<Record<keyof T, any>>): SpyObject<T> {
-  const mock: any = template || {};
+  const mock: any = { ...template } || {};
 
   installProtoMethods(mock, type.prototype, () => {
     const jestFn = jest.fn();

--- a/projects/spectator/jest/test/mock.spec.ts
+++ b/projects/spectator/jest/test/mock.spec.ts
@@ -1,0 +1,16 @@
+import { mockProvider } from '@ngneat/spectator/jest';
+
+import { WidgetService } from '../../test/widget.service';
+
+describe('mockProvider', () => {
+  it('should not modify the object passed in 2nd argument when running the mock factory', () => {
+    const customPropertiesAndMethods: Partial<Record<keyof WidgetService, any>> = {
+      testingProperty: 'overriden'
+    };
+    const { useFactory: factory } = mockProvider(WidgetService, customPropertiesAndMethods);
+    factory();
+    expect(customPropertiesAndMethods).toEqual({
+      testingProperty: 'overriden'
+    });
+  });
+});


### PR DESCRIPTION
Fix bug causing the template object to mutate when creating spy object for jest (Related to #94)



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```
