### PR TITLE
feat(schematics): add --jest flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ const createService = createServiceFactory({
 By default, Spectator uses Jasmine for creating spies. If you are using Jest as test framework instead, you can let Spectator create Jest-compatible spies.
 
 Just import one of the following functions from `@ngneat/spectator/jest`(instead of @ngneat/spectator), and it will use Jest instead of Jasmine.
-`createComponentFactory()`, `createHostFactory()`, `createServiceFactory()`, `createHttpFactory()`, `mockProvider()`
+`createComponentFactory()`, `createHostFactory()`, `createServiceFactory()`, `createHttpFactory()`, `mockProvider()`. 
 
 ```ts
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
@@ -697,6 +697,15 @@ describe('AuthService', () => {
     expect(spectator.service.isLoggedIn()).toBeTruthy();
   });
 });
+```
+
+When using the component schematic you can specify the `--jest` flag to have the Jest imports used.  In order to Jest imports the default, update `angular.json`:
+```json
+"schematics": {
+  "@ngneat/spectator:spectator-component": {
+    "jest": true
+  }
+}
 ```
 
 ## Testing with HTTP 

--- a/projects/spectator/schematics/src/spectator/component-schema.json
+++ b/projects/spectator/schematics/src/spectator/component-schema.json
@@ -139,6 +139,11 @@
       "type": "boolean",
       "default": false,
       "description": "When true, create spec with custom host"
+    },
+    "jest": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, uses Jest to create mocks."
     }
   },
   "required": [

--- a/projects/spectator/schematics/src/spectator/directive-schema.json
+++ b/projects/spectator/schematics/src/spectator/directive-schema.json
@@ -81,6 +81,11 @@
       "type": "boolean",
       "default": false,
       "description": "When true, applies lint fixes after generating the directive."
+    },
+    "jest": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, uses Jest to create mocks."
     }
   },
   "required": [

--- a/projects/spectator/schematics/src/spectator/files/component-custom-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-custom-host/__name@dasherize__.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator<% if (jest) { %>/jest<% } %>';
 
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
 

--- a/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator<% if (jest) { %>/jest<% } %>';
 
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
 

--- a/projects/spectator/schematics/src/spectator/files/component/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component/__name@dasherize__.component.spec.ts
@@ -1,4 +1,4 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator';
+import { Spectator, createComponentFactory } from '@ngneat/spectator<% if (jest) { %>/jest<% } %>';
 
 import { <%= classify(name)%>Component } from './<%= dasherize(name)%>.component';
 

--- a/projects/spectator/schematics/src/spectator/files/directive/__name@dasherize__.directive.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/directive/__name@dasherize__.directive.spec.ts
@@ -1,4 +1,4 @@
-import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator';
+import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator<% if (jest) { %>/jest<% } %>';
 
 import { <%= classify(name)%>Directive } from './<%= dasherize(name)%>.directive';
 

--- a/projects/spectator/schematics/src/spectator/schema.js.map
+++ b/projects/spectator/schematics/src/spectator/schema.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"schema.js","sourceRoot":"","sources":["schema.ts"],"names":[],"mappings":";;AAEA,MAAa,gBAAgB;CA6D5B;AA7DD,4CA6DC;AACD,MAAa,cAAc;CAgB1B;AAhBD,wCAgBC;AACD,MAAa,gBAAgB;CAmC5B;AAnCD,4CAmCC"}
+{"version":3,"file":"schema.js","sourceRoot":"","sources":["schema.ts"],"names":[],"mappings":";;AAEA,MAAa,gBAAgB;CAiE5B;AAjED,4CAiEC;AACD,MAAa,cAAc;CAoB1B;AApBD,wCAoBC;AACD,MAAa,gBAAgB;CAuC5B;AAvCD,4CAuCC"}

--- a/projects/spectator/schematics/src/spectator/schema.ts
+++ b/projects/spectator/schematics/src/spectator/schema.ts
@@ -61,6 +61,10 @@ export class ComponentOptions {
    * Specifies the view encapsulation strategy.
    */
   viewEncapsulation?: ViewEncapsulation;
+  /**
+   * Specifies if Jest is to be used for mocking
+   */
+  jest?: boolean;
 }
 export class ServiceOptions {
   name: string;
@@ -78,6 +82,10 @@ export class ServiceOptions {
    * Specifies if a spec file is generated.
    */
   spec?: boolean;
+  /**
+   * Specifies if Jest is to be used for mocking
+   */
+  jest?: boolean;
 }
 export class DirectiveOptions {
   name: string;
@@ -114,4 +122,8 @@ export class DirectiveOptions {
    * Specifies if a spec file is generated.
    */
   spec?: boolean;
+  /**
+   * Specifies if Jest is to be used for mocking
+   */
+  jest?: boolean;
 }

--- a/projects/spectator/schematics/src/spectator/service-schema.json
+++ b/projects/spectator/schematics/src/spectator/service-schema.json
@@ -52,6 +52,11 @@
       "type": "boolean",
       "default": false,
       "description": "When true, generate specs for data service"
+    },
+    "jest": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, uses Jest to create mocks."
     }
   },
   "required": [


### PR DESCRIPTION
Specifying the --jest flag imports from `@ngneat/spectator/jest`

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If you want to use the Jest enabled imports you have to manually update the import path

Issue Number: N/A


## What is the new behavior?
If you supply the `--jest` flag the Jest enabled import path will automatically be applied.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
