### PR TITLE
feat: selectOption accepts HTMLOptionElements

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ it('should set the correct option on single select when passing the element', ()
 
   spectator.selectOption(select, spectator.query(byText('Two')) as HTMLOptionElement);
 
-  expect((spectator.query(byText('Two')) as HTMLOptionElement).selected).toBe(true);
+  expect(select).toHaveSelectedOptions(spectator.query(byText('Two')) as HTMLOptionElement);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ it('should not dispatch correct number of change events', () => {
   expect(onChangeSpy).not.toHaveBeenCalledTimes(2);
 });
 ```
-You can also select `<option>` elements by passing the `HTMLOptionElement`(s) as arguments to `selectOption`. This is particularly useful when you are using `[ngValue]` binding on the `<option>`:
+You can also pass `HTMLOptionElement`(s) as arguments to `selectOption` and the `toHaveSelectedOptions` matcher. This is particularly useful when you are using `[ngValue]` binding on the `<option>`:
 ```ts
 it('should set the correct option on single select when passing the element', () => {
   const select = spectator.query('#test-single-select-element') as HTMLSelectElement;

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ It also allows you to check if your `change` event handler is acting correctly f
 
 API:
 ```ts
-spectator.selectOption(selectElement: HTMLSelectElemnt, options: string | string[], config: { emitEvents: boolean } = { emitEvents: true });
+spectator.selectOption(selectElement: HTMLSelectElement, options: string | string[] | HTMLOptionElement | HTMLOptionElement[], config: { emitEvents: boolean } = { emitEvents: true });
 ```
 
 Example:
@@ -314,6 +314,16 @@ it('should not dispatch correct number of change events', () => {
 
   expect(select).toHaveSelectedOptions(['1', '2']);
   expect(onChangeSpy).not.toHaveBeenCalledTimes(2);
+});
+```
+You can also select `<option>` elements by passing the `HTMLOptionElement`(s) as arguments to `selectOption`. This is particularly useful when you are using `[ngValue]` binding on the `<option>`:
+```ts
+it('should set the correct option on single select when passing the element', () => {
+  const select = spectator.query('#test-single-select-element') as HTMLSelectElement;
+
+  spectator.selectOption(select, spectator.query(byText('Two')) as HTMLOptionElement);
+
+  expect((spectator.query(byText('Two')) as HTMLOptionElement).selected).toBe(true);
 });
 ```
 

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -218,7 +218,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
 
   public selectOption(
     selector: SpectatorElement = this.element,
-    options: string | string[],
+    options: string | string[] | HTMLOptionElement | HTMLOptionElement[],
     config: { emitEvents: boolean } = { emitEvents: true }
   ): void {
     if (!selector) {

--- a/projects/spectator/src/lib/matchers-types.d.ts
+++ b/projects/spectator/src/lib/matchers-types.d.ts
@@ -1,3 +1,5 @@
+import { SelectOptions } from './types';
+
 declare namespace jasmine {
   interface Matchers<T> {
     toExist(): boolean;
@@ -42,6 +44,6 @@ declare namespace jasmine {
 
     toHaveDescendantWithText({ selector, text }: { selector: string; text: string }): boolean;
 
-    toHaveSelectedOptions(expected: string | string[]): boolean;
+    toHaveSelectedOptions(expected: SelectOptions): boolean;
   }
 }

--- a/projects/spectator/src/lib/matchers-types.d.ts
+++ b/projects/spectator/src/lib/matchers-types.d.ts
@@ -1,5 +1,3 @@
-import { SelectOptions } from './types';
-
 declare namespace jasmine {
   interface Matchers<T> {
     toExist(): boolean;
@@ -44,6 +42,6 @@ declare namespace jasmine {
 
     toHaveDescendantWithText({ selector, text }: { selector: string; text: string }): boolean;
 
-    toHaveSelectedOptions(expected: SelectOptions): boolean;
+    toHaveSelectedOptions(expected: string | string[] | HTMLOptionElement | HTMLOptionElement[]): boolean;
   }
 }

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -4,6 +4,7 @@
 import $ from 'jquery';
 
 import { hex2rgb, isHex, trim } from './internals/rgb-to-hex';
+import { isHTMLOptionElementArray } from './types';
 
 const hasProperty = (actual: unknown, expected: unknown): boolean => {
   return expected === undefined ? actual !== undefined : actual === expected;
@@ -359,6 +360,38 @@ export const toHaveDescendantWithText = comparator((el, { selector, text }) => {
 });
 
 export const toHaveSelectedOptions = comparator((el, expected) => {
+  if (expected instanceof HTMLOptionElement) {
+    const actual = $(el).find(':selected');
+
+    const pass = actual.is($(expected));
+
+    const message = () =>
+      `Expected element${pass ? ' not' : ''} to have options '[${expected.outerHTML}]' but had '[${actual[0].outerHTML}]'`;
+
+    return { pass, message };
+  }
+
+  if (isHTMLOptionElementArray(expected)) {
+    const actual = $(el).find(':selected');
+
+    const pass = actual.length === expected.length && actual.toArray().every((_, index) => $(actual[index]).is(expected[index]));
+
+    const expectedOptionsString = $(expected)
+      .get()
+      .map(option => option.outerHTML)
+      .join(',');
+
+    const actualOptionsString = actual
+      .get()
+      .map(option => option.outerHTML)
+      .join(',');
+
+    const message = () =>
+      `Expected element${pass ? ' not' : ''} to have options '[${expectedOptionsString}]' but had '[${actualOptionsString}]'`;
+
+    return { pass, message };
+  }
+
   const actual = $(el).val();
   const pass = JSON.stringify([...actual]) === JSON.stringify([...expected]);
 

--- a/projects/spectator/src/lib/select-option.ts
+++ b/projects/spectator/src/lib/select-option.ts
@@ -1,5 +1,5 @@
 import { dispatchFakeEvent } from './dispatch-events';
-import { isString } from './types';
+import { isString, isHTMLOptionElementArray, SelectOptions } from './types';
 
 /**
  * Focuses a select element, selects the correct options and dispatches
@@ -11,7 +11,7 @@ import { isString } from './types';
  * selectOption('al' | ['al', 'ab'], select, config);
  */
 export function selectOption(
-  options: string | string[] | HTMLOptionElement | HTMLOptionElement[],
+  options: SelectOptions,
   element: HTMLElement | HTMLSelectElement | Document | Window,
   config: { emitEvents: boolean }
 ): void {
@@ -60,8 +60,4 @@ function setOptionSelected(option: HTMLOptionElement, select: HTMLSelectElement,
   if (config.emitEvents) {
     dispatchFakeEvent(select, 'change', true);
   }
-}
-
-function isHTMLOptionElementArray(value: any): value is HTMLOptionElement[] {
-  return Array.isArray(value) && !!value.length && value.every(item => item instanceof HTMLOptionElement);
 }

--- a/projects/spectator/src/lib/select-option.ts
+++ b/projects/spectator/src/lib/select-option.ts
@@ -11,7 +11,7 @@ import { isString } from './types';
  * selectOption('al' | ['al', 'ab'], select, config);
  */
 export function selectOption(
-  options: string | string[],
+  options: string | string[] | HTMLOptionElement | HTMLOptionElement[],
   element: HTMLElement | HTMLSelectElement | Document | Window,
   config: { emitEvents: boolean }
 ): void {
@@ -28,16 +28,22 @@ export function selectOption(
     }
 
     setOptionSelected(option, element, config);
+  } else if (options instanceof HTMLOptionElement) {
+    setOptionSelected(options, element, config);
   } else {
     if (!element.multiple) {
       return;
     }
 
-    element.querySelectorAll('option').forEach(opt => {
-      if (options.includes(opt.value)) {
-        setOptionSelected(opt, element, config);
-      }
-    });
+    if (isHTMLOptionElementArray(options)) {
+      options.forEach(option => setOptionSelected(option, element, config));
+    } else {
+      element.querySelectorAll('option').forEach(opt => {
+        if (options.includes(opt.value)) {
+          setOptionSelected(opt, element, config);
+        }
+      });
+    }
   }
 }
 
@@ -54,4 +60,8 @@ function setOptionSelected(option: HTMLOptionElement, select: HTMLSelectElement,
   if (config.emitEvents) {
     dispatchFakeEvent(select, 'change', true);
   }
+}
+
+function isHTMLOptionElementArray(value: any): value is HTMLOptionElement[] {
+  return Array.isArray(value) && !!value.length && value.every(item => item instanceof HTMLOptionElement);
 }

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -18,10 +18,16 @@ export interface QueryOptions<R> {
   root?: boolean;
 }
 
+export type SelectOptions = string | string[] | HTMLOptionElement | HTMLOptionElement[];
+
 export function isString(value: any): value is string {
   return typeof value === 'string';
 }
 
 export function isType(v: any): v is Type<any> {
   return typeof v === 'function';
+}
+
+export function isHTMLOptionElementArray(value: any): value is HTMLOptionElement[] {
+  return Array.isArray(value) && !!value.length && value.every(item => item instanceof HTMLOptionElement);
 }

--- a/projects/spectator/test/form-select/form-select.component.spec.ts
+++ b/projects/spectator/test/form-select/form-select.component.spec.ts
@@ -68,9 +68,8 @@ describe('FormSelectComponent', () => {
 
     spectator.selectOption(select, spectator.query(byText('Two')) as HTMLOptionElement);
 
-    expect((spectator.query(byText('One')) as HTMLOptionElement).selected).toBe(false);
-    expect((spectator.query(byText('Two')) as HTMLOptionElement).selected).toBe(true);
-    expect((spectator.query(byText('Three')) as HTMLOptionElement).selected).toBe(false);
+    expect(select).toHaveSelectedOptions(spectator.query(byText('Two')) as HTMLOptionElement);
+    expect(select).not.toHaveSelectedOptions(spectator.query(byText('One')) as HTMLOptionElement);
   });
 
   it('should set the correct option on multi select when passing the elements', () => {
@@ -79,8 +78,7 @@ describe('FormSelectComponent', () => {
 
     spectator.selectOption(select, optionElements);
 
-    expect((spectator.query(byText('Four')) as HTMLOptionElement).selected).toBe(true);
-    expect((spectator.query(byText('Five')) as HTMLOptionElement).selected).toBe(true);
-    expect((spectator.query(byText('Six')) as HTMLOptionElement).selected).toBe(false);
+    expect(select).toHaveSelectedOptions(optionElements);
+    expect(select).not.toHaveSelectedOptions([...optionElements, spectator.query(byText('Six')) as HTMLOptionElement]);
   });
 });

--- a/projects/spectator/test/form-select/form-select.component.spec.ts
+++ b/projects/spectator/test/form-select/form-select.component.spec.ts
@@ -1,4 +1,7 @@
+import { ReactiveFormsModule } from '@angular/forms';
 import { Spectator, createComponentFactory } from '@ngneat/spectator';
+
+import { byText } from '../../src/public_api';
 
 import { FormSelectComponent } from './form-select.component';
 
@@ -6,7 +9,8 @@ describe('FormSelectComponent', () => {
   let spectator: Spectator<FormSelectComponent>;
 
   const createComponent = createComponentFactory<FormSelectComponent>({
-    component: FormSelectComponent
+    component: FormSelectComponent,
+    imports: [ReactiveFormsModule]
   });
 
   beforeEach(() => (spectator = createComponent()));
@@ -57,5 +61,26 @@ describe('FormSelectComponent', () => {
 
     expect(select).toHaveSelectedOptions(['1', '2']);
     expect(onChangeSpy).not.toHaveBeenCalledTimes(2);
+  });
+
+  it('should set the correct option on single select when passing the element', () => {
+    const select = spectator.query('#test-single-select-element') as HTMLSelectElement;
+
+    spectator.selectOption(select, spectator.query(byText('Two')) as HTMLOptionElement);
+
+    expect((spectator.query(byText('One')) as HTMLOptionElement).selected).toBe(false);
+    expect((spectator.query(byText('Two')) as HTMLOptionElement).selected).toBe(true);
+    expect((spectator.query(byText('Three')) as HTMLOptionElement).selected).toBe(false);
+  });
+
+  it('should set the correct option on multi select when passing the elements', () => {
+    const select = spectator.query('#test-multi-select-element') as HTMLSelectElement;
+    const optionElements = [spectator.query(byText('Four')) as HTMLOptionElement, spectator.query(byText('Five')) as HTMLOptionElement];
+
+    spectator.selectOption(select, optionElements);
+
+    expect((spectator.query(byText('Four')) as HTMLOptionElement).selected).toBe(true);
+    expect((spectator.query(byText('Five')) as HTMLOptionElement).selected).toBe(true);
+    expect((spectator.query(byText('Six')) as HTMLOptionElement).selected).toBe(false);
   });
 });

--- a/projects/spectator/test/form-select/form-select.component.ts
+++ b/projects/spectator/test/form-select/form-select.component.ts
@@ -18,6 +18,16 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
       <option value="2">2</option>
       <option value="3">3</option>
     </select>
+    <select id="test-single-select-element">
+      <option [ngValue]="{ id: 1 }">One</option>
+      <option [ngValue]="{ id: 2 }">Two</option>
+      <option [ngValue]="{ id: 3 }">Three</option>
+    </select>
+    <select id="test-multi-select-element" multiple>
+      <option [ngValue]="{ id: 4 }">Four</option>
+      <option [ngValue]="{ id: 5 }">Five</option>
+      <option [ngValue]="{ id: 6 }">Six</option>
+    </select>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [225](https://github.com/ngneat/spectator/issues/225)


## What is the new behavior?
Can now pass an `HTMLOptionElement` or an array of `HTMLOptionElement`s as the `options` parameter in `selectOption`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information