### PR TITLE
docs: add info on SCAM and declareComponent usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ When used like this, however, Spectator internally adds the component `ButtonCom
 Type ButtonComponent is part of the declarations of 2 modules [...]
 ```
 
-It is possible to tell Spectator not to add the component to the declarations of the internal module and, instead, use the manually defined module as is. Simply set the `declareComponent` property of the factory options to `false`:
+It is possible to tell Spectator not to add the component to the declarations of the internal module and, instead, use the explicitly defined module as is. Simply set the `declareComponent` property of the factory options to `false`:
 
 ```ts
 const createComponent = createComponentFactory({

--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ it('should work with tick', fakeAsync(() => {
 }))
 ```
 
+### Testing Single Component Angular Modules
+
+Components that are declared in their own module can be tested by defining the component 
+module in the imports list of the component factory together with the component. For example:
+
+```ts
+const createComponent = createComponentFactory({
+  component: ButtonComponent,
+  imports: [ButtonComponentModule],
+});
+```
+
+When used like this, however, Spectator internally adds the component `ButtonComponent` to the declarations of the internally created new module. Hence, you will see the following error:
+
+```
+Type ButtonComponent is part of the declarations of 2 modules [...]
+```
+
+It is possible to tell Spectator not to add the component to the declarations of the internal module and, instead, use the manually defined module as is. Simply set the `declareComponent` property of the factory options to `false`:
+
+```ts
+const createComponent = createComponentFactory({
+  component: ButtonComponent,
+  imports: [ButtonComponentModule],
+  declareComponent: false,
+});
+```
+
 ### Events API
 Each one of the events can accept a `SpectatorElement` which can be one of the following: 
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Spectator helps you get rid of all the boilerplate grunt work, leaving you with 
     - [Type Selector](#type-selector)
     - [DOM Selector](#dom-selector)
   - [Mocking Components](#mocking-components)
+  - [Testing with Single Component Angular Modules](#testing-with-single-component-angular-modules)
 - [Testing with Host](#testing-with-host)
   - [Custom Host Component](#custom-host-component)
 - [Testing with Routing](#testing-with-routing)
@@ -171,34 +172,6 @@ it('should work with tick', fakeAsync(() => {
   spectator.tick(6000);
   expect(spectator.component.updatedAsync).not.toBeFalsy();
 }))
-```
-
-### Testing Single Component Angular Modules
-
-Components that are declared in their own module can be tested by defining the component 
-module in the imports list of the component factory together with the component. For example:
-
-```ts
-const createComponent = createComponentFactory({
-  component: ButtonComponent,
-  imports: [ButtonComponentModule],
-});
-```
-
-When used like this, however, Spectator internally adds the component `ButtonComponent` to the declarations of the internally created new module. Hence, you will see the following error:
-
-```
-Type ButtonComponent is part of the declarations of 2 modules [...]
-```
-
-It is possible to tell Spectator not to add the component to the declarations of the internal module and, instead, use the explicitly defined module as is. Simply set the `declareComponent` property of the factory options to `false`:
-
-```ts
-const createComponent = createComponentFactory({
-  component: ButtonComponent,
-  imports: [ButtonComponentModule],
-  declareComponent: false,
-});
 ```
 
 ### Events API
@@ -370,6 +343,34 @@ const createHost = createHostFactory({
   declarations: [
     MockComponent(FooComponent)
   ]
+});
+```
+
+#### Testing with Single Component Angular Modules
+
+Components that are declared in their own module can be tested by defining the component 
+module in the imports list of the component factory together with the component. For example:
+
+```ts
+const createComponent = createComponentFactory({
+  component: ButtonComponent,
+  imports: [ButtonComponentModule],
+});
+```
+
+When used like this, however, Spectator internally adds the component `ButtonComponent` to the declarations of the internally created new module. Hence, you will see the following error:
+
+```
+Type ButtonComponent is part of the declarations of 2 modules [...]
+```
+
+It is possible to tell Spectator not to add the component to the declarations of the internal module and, instead, use the explicitly defined module as is. Simply set the `declareComponent` property of the factory options to `false`:
+
+```ts
+const createComponent = createComponentFactory({
+  component: ButtonComponent,
+  imports: [ButtonComponentModule],
+  declareComponent: false,
 });
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Documentation content changes
[ ] Other... Please describe:
```

Add documentation on how to test components which are included in a module specific to that component. Its not necessary then to define the imports list again and instead use the module as it is.

It took me some time check the code if it is possible at all to avoide the described error and, thus, I found the property is already there but not described.
