### PR TITLE
feat(matchers): add more custom matchers to the API #217

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,11 +854,25 @@ expect('.zippy__content').toHaveLength(3);
 expect('.zippy__content').toHaveId('id');
 expect('.zippy__content').toHaveClass('class');
 expect('.zippy__content').toHaveClass('class a, class b');
+expect('.zippy__content').toHaveClass(['class a', 'class b']);
 expect(spectator.query('.zippy')).toHaveAttribute('id', 'zippy');
+expect(spectator.query('.zippy')).toHaveAttribute({id: 'zippy'});
 expect(spectator.query('.checkbox')).toHaveProperty('checked', true);
+expect(spectator.query('.img')).toHaveProperty({src: 'assets/myimg.jpg'});
+expect(spectator.query('.img')).toContainProperty({src: 'myimg.jpg'});
 expect('.zippy__content').toHaveText('Content');
+expect('.zippy__content').toContainText('Content');
+
+// Note this looks for multiple elements with the class and checks the text of each array element against the index of the element found
+expect('.zippy__content').toHaveText(['Content A', 'Content B']); 
+expect('.zippy__content').toContainText(['Content A', 'Content B']); 
 expect('.zippy__content').toHaveText((text) => text.includes('..'));
 expect('.zippy__content').toHaveValue('value');
+expect('.zippy__content').toContainValue('value');
+
+// Note this looks for multiple elements with the class and checks the value of each array element against the index of the element found
+expect('.zippy__content').toHaveValue(['value a', 'value b']);
+expect('.zippy__content').toContainValue(['value a', 'value b']);
 expect(spectator.element).toHaveStyle({backgroundColor: 'rgba(0, 0, 0, 0.1)'});
 expect('.zippy__content').toHaveData({data: 'role', val: 'admin'});
 expect('.checkbox').toBeChecked();

--- a/projects/spectator/jest/src/lib/matchers-types.d.ts
+++ b/projects/spectator/jest/src/lib/matchers-types.d.ts
@@ -6,17 +6,23 @@ declare namespace jest {
 
     toHaveId(id: string | number): boolean;
 
-    toHaveClass(className: string): boolean;
+    toHaveClass(className: string | string[]): boolean;
 
-    toHaveAttribute(attr: string, val?: string): boolean;
+    toHaveAttribute(attr: string | object, val?: string): boolean;
 
-    toHaveProperty(prop: string, val: string | boolean): boolean;
+    toHaveProperty(prop: string | object, val?: string | boolean): boolean;
 
-    toHaveText(text: string | Function, exact?: boolean): boolean;
+    toContainProperty(prop: string | object, val?: string): boolean;
 
-    toHaveExactText(text: string | Function): boolean;
+    toHaveText(text: string | string[] | Function, exact?: boolean): boolean;
 
-    toHaveValue(value: string): boolean;
+    toContainText(text: string | string[] | Function, exact?: boolean): boolean;
+
+    toHaveExactText(text: string | string[] | Function): boolean;
+
+    toHaveValue(value: string | string[]): boolean;
+
+    toContainValue(value: string | string[]): boolean;
 
     toHaveStyle(style: { [styleKey: string]: any }): boolean;
 

--- a/projects/spectator/src/lib/matchers-types.d.ts
+++ b/projects/spectator/src/lib/matchers-types.d.ts
@@ -6,17 +6,23 @@ declare namespace jasmine {
 
     toHaveId(id: string | number): boolean;
 
-    toHaveClass(className: string): boolean;
+    toHaveClass(className: string | string[]): boolean;
 
-    toHaveAttribute(attr: string, val?: string): boolean;
+    toHaveAttribute(attr: string | object, val?: string): boolean;
 
-    toHaveProperty(prop: string, val: string | boolean): boolean;
+    toHaveProperty(prop: string | object, val?: string | boolean): boolean;
 
-    toHaveText(text: string | Function, exact?: boolean): boolean;
+    toContainProperty(prop: string | object, val?: string): boolean;
 
-    toHaveExactText(text: string | Function): boolean;
+    toHaveText(text: string | string[] | Function, exact?: boolean): boolean;
 
-    toHaveValue(value: string): boolean;
+    toContainText(text: string | string[] | Function, exact?: boolean): boolean;
+
+    toHaveExactText(text: string | string[] | Function): boolean;
+
+    toHaveValue(value: string | string[]): boolean;
+
+    toContainValue(value: string | string[]): boolean;
 
     toHaveStyle(style: { [styleKey: string]: any }): boolean;
 

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -31,3 +31,7 @@ export function isType(v: any): v is Type<any> {
 export function isHTMLOptionElementArray(value: any): value is HTMLOptionElement[] {
   return Array.isArray(value) && !!value.length && value.every(item => item instanceof HTMLOptionElement);
 }
+
+export function isObject(v: any): v is object {
+  return v && typeof v === 'object';
+}

--- a/projects/spectator/test/matcher-enhancements/matcher-enhancements.component.spec.ts
+++ b/projects/spectator/test/matcher-enhancements/matcher-enhancements.component.spec.ts
@@ -1,0 +1,41 @@
+import { Spectator, createComponentFactory } from '@ngneat/spectator';
+
+import { MatcherEnhancementsComponent } from './matcher-enhancements.component';
+
+describe('Matcher Enchancements Test', () => {
+  let spectator: Spectator<MatcherEnhancementsComponent>;
+  const createComponent = createComponentFactory({
+    component: MatcherEnhancementsComponent
+  });
+
+  beforeEach(() => (spectator = createComponent()));
+
+  it('should match mulitple elements with different text', () => {
+    const el = spectator.query('.text-check');
+    expect(el).toHaveText(['It should', 'different text']);
+    expect(el).toContainText(['It should', 'different text']);
+    expect(el).toHaveExactText(['It should have', 'Some different text']);
+  });
+
+  it('should match multiple inputs with different values', () => {
+    const inputs = spectator.queryAll('input.sample');
+    expect(inputs).toHaveValue(['test1', 'test2']);
+    expect(inputs).toContainValue(['test1', 'test2']);
+  });
+
+  it('should match multiple classes on an element', () => {
+    expect(spectator.query('#multi-class')).toHaveClass(['one-class', 'two-class']);
+  });
+
+  it('should match attributes with object syntax', () => {
+    expect(spectator.query('#attr-check')).toHaveAttribute({ label: 'test label' });
+  });
+
+  it('should match properties with object syntax', () => {
+    expect(spectator.query('.checkbox')).toHaveProperty({ checked: true });
+  });
+
+  it('should match partial properties with object syntax', () => {
+    expect(spectator.query('img')).toContainProperty({ src: 'assets/myimg.jpg' });
+  });
+});

--- a/projects/spectator/test/matcher-enhancements/matcher-enhancements.component.ts
+++ b/projects/spectator/test/matcher-enhancements/matcher-enhancements.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'matcher-enhancements',
+  template: `
+    <div class="text-check">It should have</div>
+    <div class="text-check">Some different text</div>
+    <div class="one-class two-class" id="multi-class"></div>
+    <input class="sample" value="test1" />
+    <input class="sample" value="test2" />
+    <input class="checkbox" type="checkbox" checked />
+    <div id="attr-check" label="test label"></div>
+    <img src="http://localhost:8080/assets/myimg.jpg" />
+  `
+})
+export class MatcherEnhancementsComponent {}


### PR DESCRIPTION
Add additional custom matchers to the API

close #217

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```ts
expect('.zippy').toHaveClass('class a, class b');
expect('some option').toHaveText('Content 1, Content 2, Content 3');
expect('some input').toHaveValue('value 1, value 2, value 3');
expect('.zippy').toHaveAttribute('id', 'zippy');
expect('.zippy').toHaveAttribute('name', 'zippy');
expect('img').toHaveProperty('src', 'http://localhost:9876/assset/toto.png');
expect('img').toHaveProperty('alt', 'An image');
```
Issue Number: #217 


## What is the new behavior?
Add array support for selectors matchers with multiple results
```ts
expect('.zippy').toHaveClass(['class a', 'class b']);
expect('some option').toHaveText(['Content 1', 'Content 2', 'Content 3']);
expect('some input').toHaveValue(['value 1', 'value 2', 'value 3']);
```
Add contains variant for Text and Value matchers
```ts
expect('option').toContainsText('Content 1');
expect('some option').toContainsText(['Content 1', 'Content 2', 'Content 3']);
expect('input').toContainsValue('value 1');
expect('some input').toContainsValue(['value 1', 'value 2', 'value 3']);
```
Add object support for Attribute and Property
```ts
expect('.zippy').toHaveAttribute({
  'id':  'zippy',
  'name':  'zippy',
});
expect('checkbox').toHaveProperty({
  'src': 'http://localhost:9876/assset/toto.png',
  'alt':  'An image',
});
```

Add contains support for Attribute and Property (to avoid to write http://localhost:9876 for src as example)
```ts
expect('checkbox').toContainsProperty({
  'src': '/assset/toto.png',
  'alt':  'An image',
});
```

## Does this PR introduce a breaking change?
 - [x] No
