### PR TITLE
fix(spectator): fix for incorrect type definition on queryHostAll (#230)

### DIFF
--- a/projects/spectator/src/lib/spectator-host/spectator-host.ts
+++ b/projects/spectator/src/lib/spectator-host/spectator-host.ts
@@ -41,7 +41,7 @@ export class SpectatorHost<C, H = HostComponent> extends Spectator<C> {
     return getChildren<R>(this.hostDebugElement)(directiveOrSelector, options)[0] || null;
   }
 
-  public queryHostAll<R extends Element[]>(selector: string | DOMSelector, options?: { root: boolean }): R[];
+  public queryHostAll<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R[];
   public queryHostAll<R>(directive: Type<R>): R[];
   public queryHostAll<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R[];
   public queryHostAll<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R[] | Element[] {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
   * all tests passed and this is just a type definition change, so I didn't see a need
- [x] Docs have been added / updated (for bug fixes / features)
   * looked through the docs didn't see anything related to type information around queryHostAll


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ x] Other... Please describe:
```
A change to the type definition of queryHostAll.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/ngneat/spectator/issues/230
Issue Number: 230


## What is the new behavior?
I changed the type of queryHostAll from <R extends Element[]> to <R extends Element>.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```
🤷‍♂ 
I would assume a change to a type definition would be a breaking change, but a simple refactor would take care of that.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
