### PR TITLE
 feat(spectator): added expectConcurrent to spectator-http (#231)

### DIFF
--- a/projects/spectator/src/lib/http.ts
+++ b/projects/spectator/src/lib/http.ts
@@ -24,6 +24,8 @@ export function createHTTPFactory<S>(
       controller: spectator.controller,
       httpClient: spectator.httpClient,
       expectOne: spectator.expectOne.bind(spectator),
+      expectConcurrent: spectator.expectConcurrent.bind(spectator),
+      flushAll: spectator.flushAll,
       get: spectator.get.bind(spectator)
     };
   };

--- a/projects/spectator/src/lib/spectator-http/spectator-http.ts
+++ b/projects/spectator/src/lib/spectator-http/spectator-http.ts
@@ -17,6 +17,11 @@ export enum HttpMethod {
   OPTIONS = 'OPTIONS'
 }
 
+export interface HttpExpect {
+  url: string;
+  method: HttpMethod;
+}
+
 /**
  * @publicApi
  */
@@ -32,6 +37,7 @@ export class SpectatorHttp<S> extends BaseSpectator {
     // small workaround to prevent issues if destructuring SpectatorHttp, which was common in Spectator 3
     // remove in v5?
     this.expectOne = this.expectOne.bind(this);
+    this.expectConcurrent = this.expectConcurrent.bind(this);
     this.dataService = service;
   }
 
@@ -47,5 +53,24 @@ export class SpectatorHttp<S> extends BaseSpectator {
     this.controller.verify();
 
     return req;
+  }
+
+  public expectConcurrent(expectations: HttpExpect[]): TestRequest[] {
+    const requests = expectations.map((expectation: HttpExpect) => {
+      return this.controller.expectOne({
+        url: expectation.url,
+        method: expectation.method
+      });
+    });
+
+    this.controller.verify();
+
+    return requests;
+  }
+
+  public flushAll(requests: TestRequest[], args: any[]): void {
+    requests.forEach((request: TestRequest, idx: number) => {
+      request.flush(args[idx]);
+    });
   }
 }

--- a/projects/spectator/test/todos-data.service.spec.ts
+++ b/projects/spectator/test/todos-data.service.spec.ts
@@ -35,6 +35,14 @@ describe('HttpClient testing', () => {
     spectatorHttp.expectOne('two', HttpMethod.GET);
   });
 
+  it('should test concurrent requests', () => {
+    const spectatorHttp = http();
+
+    spectatorHttp.service.concurrentRequests().subscribe();
+    const reqs = spectatorHttp.expectConcurrent(['one', 'two', 'three'].map(url => ({ url, method: HttpMethod.POST })));
+    spectatorHttp.flushAll(reqs, Array.from({ length: 3 }, _ => ({})));
+  });
+
   it('should work with external service', fakeAsync(() => {
     const spectatorHttp = http();
     spectatorHttp.get(UserService).getUser.andCallFake(() => {

--- a/projects/spectator/test/todos-data.service.ts
+++ b/projects/spectator/test/todos-data.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { defer, Observable } from 'rxjs';
+import { defer, Observable, merge } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 
 export class UserService {
@@ -27,6 +27,10 @@ export class TodosDataService {
         return this.http.get('two');
       })
     );
+  }
+
+  public concurrentRequests(): Observable<any> {
+    return merge(this.http.post('one', {}), this.http.post('two', {}), this.http.post('three', {}));
   }
 
   public requestWithExternalService(): Observable<any> {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
An addition to the SpectatorHttp API.
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`spectator.expectOne()` calls `this.controller.verify()` which causes tests to fail if there are concurrent requests going out.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 231

## What is the new behavior?
Adding `spectator.expectConcurrent()` allows for expecting multiple requests.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
