### PR TITLE
feat(spectator): added directiveProviders to spectator-directive (#236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,9 @@ To access the provider, get it from the component injector using the `fromCompon
 spectator.get(FooService, true)
 ```
 
+The same rules also apply to directives using the `directiveProviders` and `directiveMocks` parameters.
+
+
 ## Custom Matchers
 ```ts
 expect('.zippy__content').not.toExist();

--- a/projects/spectator/src/lib/spectator-directive/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-directive/create-factory.ts
@@ -29,6 +29,7 @@ export interface SpectatorDirectiveOverrides<D, H, HP> extends BaseSpectatorOver
   detectChanges?: boolean;
   props?: Partial<D>;
   hostProps?: HostComponent extends H ? HP : Partial<H>;
+  directiveProviders?: Provider[];
 }
 
 /**
@@ -49,7 +50,12 @@ export function createDirectiveFactory<D, H = HostComponent>(
   }));
 
   return <HP>(template: string, overrides?: SpectatorDirectiveOverrides<D, H, HP>) => {
-    const defaults: SpectatorDirectiveOverrides<D, H, HP> = { props: {}, hostProps: {} as any, detectChanges: true, providers: [] };
+    const defaults: SpectatorDirectiveOverrides<D, H, HP> = {
+      props: {},
+      hostProps: {} as any,
+      detectChanges: true,
+      providers: []
+    };
     const { detectChanges, props, hostProps, providers } = { ...defaults, ...overrides };
 
     if (providers && providers.length) {
@@ -65,6 +71,12 @@ export function createDirectiveFactory<D, H = HostComponent>(
     }).overrideComponent(options.host, {
       set: { template }
     });
+
+    if (options.directiveProviders.length || options.directiveMocks.length) {
+      TestBed.overrideDirective(options.directive, {
+        set: { providers: [...options.directiveProviders, ...options.directiveMocks.map(p => options.mockProvider(p))] }
+      });
+    }
 
     const spectator = createSpectatorDirective(options, props, hostProps);
 

--- a/projects/spectator/src/lib/spectator-directive/options.ts
+++ b/projects/spectator/src/lib/spectator-directive/options.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { Type, Provider } from '@angular/core';
 
 import { merge } from '../internals/merge';
 import { OptionalsRequired } from '../types';
@@ -14,6 +14,8 @@ export interface SpectatorDirectiveOptions<D, H> extends BaseSpectatorOptions {
   detectChanges?: boolean;
   host?: Type<H>;
   template?: string;
+  directiveProviders?: Provider[];
+  directiveMocks?: Type<any>[];
 }
 
 const defaultSpectatorRoutingOptions: OptionalsRequired<SpectatorDirectiveOptions<any, any>> = {
@@ -21,7 +23,9 @@ const defaultSpectatorRoutingOptions: OptionalsRequired<SpectatorDirectiveOption
   host: HostComponent,
   template: '',
   shallow: false,
-  detectChanges: true
+  detectChanges: true,
+  directiveProviders: [],
+  directiveMocks: []
 };
 
 /**

--- a/projects/spectator/test/directive-providers.directive.spec.ts
+++ b/projects/spectator/test/directive-providers.directive.spec.ts
@@ -1,0 +1,20 @@
+import { FormBuilder } from '@angular/forms';
+import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator';
+
+import { DirectiveProviderDirective, directiveProviderToken } from './directive-providers.directive';
+
+describe('DirectiveProviderDirective', () => {
+  let host: SpectatorDirective<DirectiveProviderDirective>;
+
+  const createHost = createDirectiveFactory({
+    directive: DirectiveProviderDirective,
+    directiveProviders: [{ provide: directiveProviderToken, useValue: 'notTest' }],
+    directiveMocks: [FormBuilder]
+  });
+
+  it('should inject the provided value', () => {
+    host = createHost(`<div directiveProvider>Testing Directive Providers</div>`);
+
+    expect(host.directive.provider).toEqual('notTest');
+  });
+});

--- a/projects/spectator/test/directive-providers.directive.ts
+++ b/projects/spectator/test/directive-providers.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, Inject, InjectionToken } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+
+export const directiveProviderToken = new InjectionToken('DirectiveProviderToken');
+
+@Directive({
+  selector: '[directiveProvider]',
+  providers: [{ provide: directiveProviderToken, useValue: 'test' }]
+})
+export class DirectiveProviderDirective {
+  constructor(@Inject(directiveProviderToken) public provider: string, private fb: FormBuilder) {}
+}


### PR DESCRIPTION
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #236 

## What is the new behavior?
Now it is possible to override the directive providers with mocks or with own providers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
