### PR TITLE
feat: added modifier key support to keyboard api (#241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ spectator.keyboard.pressEscape();
 spectator.keyboard.pressTab();
 spectator.keyboard.pressBackspace();
 spectator.keyboard.pressKey('a');
+spectator.keyboard.pressKey('ctrl.a');
+spectator.keyboard.pressKey('ctrl.shift.a');
 ```
 
 ### Mouse helpers

--- a/projects/spectator/src/lib/internals/key-parser.ts
+++ b/projects/spectator/src/lib/internals/key-parser.ts
@@ -1,0 +1,65 @@
+import { isNumber, isString } from '../types';
+
+export interface ModifierKeys {
+  alt?: boolean;
+  control?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+}
+
+export interface KeyOptions {
+  key: string | false;
+  keyCode: number | false;
+  modifiers: ModifierKeys;
+}
+
+export const parseKeyOptions = (keyOrKeyCode: string | number): KeyOptions => {
+  if (isNumber(keyOrKeyCode) && keyOrKeyCode) {
+    return { key: false, keyCode: keyOrKeyCode, modifiers: {} };
+  }
+
+  if (isString(keyOrKeyCode) && keyOrKeyCode) {
+    return parseKey(keyOrKeyCode as string);
+  }
+
+  throw new Error('keyboard.pressKey() requires a valid key or keyCode');
+};
+
+const parseKey = (keyStr: string): KeyOptions => {
+  if (keyStr.indexOf('.') < 0) {
+    return { key: keyStr, keyCode: false, modifiers: {} };
+  }
+
+  const keyParts = keyStr.split('.');
+  const key = keyParts.pop() as string;
+  const modifiers = keyParts.reduce(
+    (mods, part) => {
+      switch (part) {
+        case 'control':
+        case 'ctrl':
+          mods.control = true;
+
+          return mods;
+        case 'shift':
+          mods.shift = true;
+
+          return mods;
+        case 'alt':
+          mods.alt = true;
+
+          return mods;
+        case 'meta':
+        case 'cmd':
+        case 'win':
+          mods.meta = true;
+
+          return mods;
+        default:
+          throw new Error(`invalid key modifier: ${part}`);
+      }
+    },
+    { alt: false, control: false, shift: false, meta: false }
+  );
+
+  return { key, keyCode: false, modifiers };
+};

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -24,6 +24,10 @@ export function isString(value: any): value is string {
   return typeof value === 'string';
 }
 
+export function isNumber(value: any): value is number {
+  return typeof value === 'number';
+}
+
 export function isType(v: any): v is Type<any> {
   return typeof v === 'function';
 }

--- a/projects/spectator/test/events/events.component.html
+++ b/projects/spectator/test/events/events.component.html
@@ -1,3 +1,4 @@
 <h1>{{ event }}</h1>
-<input type="text" (blur)="onBlur()" (focus)="onFocus()" (keyup.a)="onPressA()">
+<input type="text" (blur)="onBlur()" (focus)="onFocus()" (keyup.a)="onPressA()" (keyup.control.a)="onPressCtrlA()"
+        (keyup.control.shift.a)="onPressCtrlShiftA()">
 

--- a/projects/spectator/test/events/events.component.spec.ts
+++ b/projects/spectator/test/events/events.component.spec.ts
@@ -14,7 +14,12 @@ describe('EventsComponent', () => {
     expect(spectator.query('h1')).toHaveText('focus');
     spectator.blur('input');
     expect(spectator.query('h1')).toHaveText('blur');
+
     spectator.keyboard.pressKey('a', 'input');
     expect(spectator.query('h1')).toHaveText('pressed a');
+    spectator.keyboard.pressKey('ctrl.a', 'input');
+    expect(spectator.query('h1')).toHaveText('pressed ctrl.a');
+    spectator.keyboard.pressKey('ctrl.shift.a', 'input');
+    expect(spectator.query('h1')).toHaveText('pressed ctrl.shift.a');
   });
 });

--- a/projects/spectator/test/events/events.component.ts
+++ b/projects/spectator/test/events/events.component.ts
@@ -19,4 +19,12 @@ export class EventsComponent {
   public onPressA(): void {
     this.event = 'pressed a';
   }
+
+  public onPressCtrlA(): void {
+    this.event = 'pressed ctrl.a';
+  }
+
+  public onPressCtrlShiftA(): void {
+    this.event = 'pressed ctrl.shift.a';
+  }
 }


### PR DESCRIPTION
This commit adds support to spectator.keyboard.pressKey() for triggering
key events with modifier keys.

Example, spectator.keyboard.pressKey('ctrl.shift.a').

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Right now, `spectator.keyboard.pressKey()` does not support key events with key modifiers (meta, ctrl, alt, shift). `spectator.keyboard.pressKey('ctrl.a')` would produce an error.

Issue Number: 241


## What is the new behavior?
With this PR, `spectator.keyboard.pressKey('ctrl.a')` will produce a key event that indicates the control key was being pressed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
