### PR TITLE
fix(matchers): 🐛 add toHaveSelectedOptions matcher for jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3272,7 +3272,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
@@ -5660,7 +5660,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -5697,7 +5697,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -7298,7 +7298,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -7311,7 +7311,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -7869,7 +7869,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -7960,7 +7960,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -16030,7 +16030,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -17184,7 +17184,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/projects/spectator/jest/src/lib/matchers-types.d.ts
+++ b/projects/spectator/jest/src/lib/matchers-types.d.ts
@@ -47,5 +47,7 @@ declare namespace jest {
     toHaveDescendant(selector: string | Element): boolean;
 
     toHaveDescendantWithText({ selector, text }: { selector: string; text: string }): boolean;
+
+    toHaveSelectedOptions(expected: string | string[] | HTMLOptionElement | HTMLOptionElement[]): boolean;
   }
 }

--- a/projects/spectator/jest/test/form-select/form-select.component.spec.ts
+++ b/projects/spectator/jest/test/form-select/form-select.component.spec.ts
@@ -1,0 +1,21 @@
+import { ReactiveFormsModule } from '@angular/forms';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+
+import { FormSelectComponent } from './form-select.component';
+
+describe('FormSelectComponent', () => {
+  let spectator: Spectator<FormSelectComponent>;
+
+  const createComponent = createComponentFactory<FormSelectComponent>({
+    component: FormSelectComponent,
+    imports: [ReactiveFormsModule]
+  });
+
+  beforeEach(() => (spectator = createComponent()));
+
+  it('should set the correct option on standard select', () => {
+    const select = spectator.query('#test-single-select') as HTMLSelectElement;
+    spectator.selectOption(select, '1');
+    expect(select).toHaveSelectedOptions('1');
+  });
+});

--- a/projects/spectator/jest/test/form-select/form-select.component.ts
+++ b/projects/spectator/jest/test/form-select/form-select.component.ts
@@ -1,0 +1,21 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-form-select',
+  template: `
+    <select id="test-single-select">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </select>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FormSelectComponent {
+  /**
+   * Empty method to spy on
+   */
+  public handleChange(): void {
+    return;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When using `toHaveSelectedOptionsMatcher` with Jest, tests fail with the error `Property 'toHaveSelectedOptions' does not exist on type 'Matchers<HTMLSelectElement>'`. Works fine for Jasmine tests.


## What is the new behavior?
Tests run in Jest without error

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information