### PR TITLE
fix(mathers): fix passing toHaveStyle if styles applied in attr (#270)

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -51,7 +51,7 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
         continue;
       }
 
-      if (trim($el.css(prop)) !== trim(value)) {
+      if (trim($el.css(prop)) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
         return false;
       }
     }

--- a/projects/spectator/test/hello/hello.component.spec.ts
+++ b/projects/spectator/test/hello/hello.component.spec.ts
@@ -17,6 +17,13 @@ describe('HelloComponent', () => {
 
     expect((host.query('div') as HTMLElement).style.width).toBe('20px');
 
+    expect(host.query('div') as HTMLElement).toHaveStyle({ width: '20px' });
+    expect(host.query('div') as HTMLElement).not.toHaveStyle({ width: '30px' });
+    expect(host.query('div') as HTMLElement).toHaveStyle({ display: 'flex' });
+    expect(host.query('div') as HTMLElement).not.toHaveStyle({ display: 'block' });
+    expect(host.query('div') as HTMLElement).toHaveStyle({ width: '20px', display: 'flex' });
+    expect(host.query('div') as HTMLElement).not.toHaveStyle({ width: '20px', display: 'block' });
+
     expect('div h1').toHaveText(''); // This should return true, according to the original code
     expect('div h1').toHaveText('some title');
     expect('div h1').toHaveText('ome title');

--- a/projects/spectator/test/hello/hello.component.ts
+++ b/projects/spectator/test/hello/hello.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '../translate.service';
 @Component({
   selector: 'hello',
   template: `
-    <div [style.width]="width">
+    <div [style.width]="width" style="display: flex;">
       <h1>{{ title | translate }}</h1>
     </div>
 


### PR DESCRIPTION
Used .css() method from JQuery are using .getComputedStyles(element) in core but it's not always passing in testing with jest though styles are applied directly to element and also are existing in .getComputedStyles(element) result in browser.
So need to fail tests in toHaveStyle matcher only if both JQuery .css() and HTMLElement.style objects don't contain specified property with specified value

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #270 


## What is the new behavior?
Working as expected, see #270 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This may fail tests in very edge cases, like:
`expect(...).not.toHaveStyle(...)`
if these styles were applied to element using attrubutes: style, [style....], [ngStyle] and similar.

To resolve these tests need to remove `.not` part.


## Other information
