### PR TITLE
fix: schematics service for jest

### DIFF
--- a/projects/spectator/schematics/src/spectator/files/service/__name@dasherize__.service.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/service/__name@dasherize__.service.spec.ts
@@ -1,4 +1,4 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator<% if (jest) { %>/jest<% } %>';
 import { <%= classify(name)%>Service } from './<%= dasherize(name)%>.service';
 
 describe('<%= classify(name)%>Service', () => {


### PR DESCRIPTION
Add missing condition to load factory and service from jest module.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Generating service for jest doesn't import from Jest module.

Issue Number: 272


## What is the new behavior?
Import from the appropriate module

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
I had to bypass the precommit hooks as prettier doesn't accept the schematics syntax in the import
