### PR TITLE
feat(lib): use TestBed.get if .inject falsy - back compatibility (#283)

### DIFF
--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -29,9 +29,9 @@
     "replace-in-file": "^4.1.3"
   },
   "peerDependencies": {
-    "@angular/common": "^8.0.0",
-    "@angular/core": "^8.0.0",
-    "@angular/router": "^8.0.0",
+    "@angular/common": ">= 8.0.0",
+    "@angular/core": ">= 8.0.0",
+    "@angular/router": ">= 8.0.0",
     "typescript": ">= 3.7.0"
   },
   "bin": {

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -32,7 +32,7 @@
     "@angular/common": ">= 8.0.0",
     "@angular/core": ">= 8.0.0",
     "@angular/router": ">= 8.0.0",
-    "typescript": ">= 3.7.0"
+    "typescript": ">= 2.8.0"
   },
   "bin": {
     "spectator-migrate": "./migrate.js"

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -29,9 +29,9 @@
     "replace-in-file": "^4.1.3"
   },
   "peerDependencies": {
-    "@angular/common": "^9.0.1",
-    "@angular/core": "^9.0.1",
-    "@angular/router": "^9.0.1",
+    "@angular/common": "^8.0.0",
+    "@angular/core": "^8.0.0",
+    "@angular/router": "^8.0.0",
     "typescript": ">= 3.7.0"
   },
   "bin": {

--- a/projects/spectator/src/lib/base/base-spectator.ts
+++ b/projects/spectator/src/lib/base/base-spectator.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, TestBedStatic } from '@angular/core/testing';
 
 import { SpyObject } from '../mock';
 import { Token } from '../token';
@@ -17,6 +17,6 @@ export abstract class BaseSpectator {
   }
 
   public inject<T>(token: Token<T>): SpyObject<T> {
-    return TestBed.inject(token) as SpyObject<T>;
+    return (<any>TestBed).inject ? ((<any>TestBed).inject(token) as SpyObject<T>) : TestBed.get(token);
   }
 }

--- a/projects/spectator/src/lib/spectator-http/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-http/create-factory.ts
@@ -34,7 +34,11 @@ export function createHttpFactory<S>(typeOrOptions: Type<S> | SpectatorHttpOptio
   });
 
   afterEach(() => {
-    TestBed.inject(HttpTestingController).verify();
+    if ((<any>TestBed).inject) {
+      (<any>TestBed).inject(HttpTestingController).verify();
+    } else {
+      TestBed.get(HttpTestingController).verify();
+    }
   });
 
   return (overrides?: CreateHttpOverrides<S>) => {

--- a/projects/spectator/src/lib/spectator-service/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-service/create-factory.ts
@@ -1,5 +1,5 @@
 import { Provider, Type } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { TestBed, TestBedStatic } from '@angular/core/testing';
 
 import { BaseSpectatorOverrides } from '../base/options';
 import { isType, doesServiceImplementsOnDestroy } from '../types';
@@ -33,7 +33,9 @@ export function createServiceFactory<S>(typeOrOptions: Type<S> | SpectatorServic
   });
 
   afterEach(() => {
-    const testedService = TestBed.inject<S>(service);
+    const testedService = (<any>TestBed).inject
+      ? (<{ inject<T>(token: Type<T>, notFoundValue?: T): T } & TestBedStatic>TestBed).inject<S>(service)
+      : TestBed.get(service);
 
     if (doesServiceImplementsOnDestroy(testedService)) {
       // tslint:disable-next-line:no-life-cycle-call


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Backward compatibility change.
Allow to use 5.x lib version for Angular version less than v9.
Keep to use for Angular v9 as is.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #283 


## What is the new behavior?
You can continue using the latest version of Spectator in you Angular projects with version less than 9 (e.g. 7, 8 etc.)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
