### PR TITLE
fix(rgb-to-hex): fix trim function to handle falsy value(#270)

### DIFF
--- a/projects/spectator/src/lib/internals/rgb-to-hex.ts
+++ b/projects/spectator/src/lib/internals/rgb-to-hex.ts
@@ -19,5 +19,5 @@ export function isHex(value: string): boolean {
 }
 
 export function trim(value: string): string {
-  return value.replace(/\s/g, '');
+  return (value || '').replace(/\s/g, '');
 }

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -52,7 +52,7 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
         continue;
       }
 
-      if (trim($el.css(prop) || '') !== trim(value) && trim(el.style[prop] || '') !== trim(value)) {
+      if (trim($el.css(prop)) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
         return false;
       }
     }

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -52,7 +52,7 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
         continue;
       }
 
-      if (trim($el.css(prop)) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
+      if (trim($el.css(prop) || '') !== trim(value) && trim(el.style[prop] || '') !== trim(value)) {
         return false;
       }
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Additional fix for #270 

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Throws error 'replace of null' in trim() function when jQuery.css() returns null in hasCss matcher.

Issue Number: #270


## What is the new behavior?
If jQuery.css() returns null pass empty string (`''`) to trim() function.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
