### PR TITLE
docs(schematics): syntax update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ The `spectator` schematics extend the default `@schematics/angular` collection. 
 ```json
 "schematics": {
   "@ngneat/spectator:spectator-component": {
-    "styleext": "scss"
+    "style": "scss"
   }
 }
 ```


### PR DESCRIPTION
'styleext' changed to 'style'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Incorrect documentation of using scss in schematics.

Issue Number: N/A


## What is the new behavior?
Corrected documentation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```

## Other information
This syntax was changed in Angular6 with `styleext` being deprecated in favor of `style`.