### PR TITLE
feat(dom-selectors): add `selector` option to `byText` query

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ spectator.query(byTitle('By title'));
 spectator.query(byAltText('By alt text'));
 spectator.query(byLabel('By label'));
 spectator.query(byText('By text'));
+spectator.query(byText('By text', {selector: '#some .selector'}));
 ```
 #### Testing Select Elements
 Spectator allows you to test `<select></select>` elements easily, and supports multi select.

--- a/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -15,6 +15,15 @@ describe('DomSelectorsComponent', () => {
     expect(element).toHaveId('by-text-p');
   });
 
+  it('should allow querying by text and selector', () => {
+    const element = spectator.query(byText('By text', { selector: '#by-text-p-2' }));
+    expect(element).toHaveId('by-text-p-2');
+
+    const elements = spectator.queryAll(byText('By text', { selector: '#by-text-p-2' }));
+    expect(elements[0]).toHaveId('by-text-p-2');
+    expect(elements).toHaveLength(1);
+  });
+
   it('should allow querying by label', () => {
     const element = spectator.query(byLabel('By label'));
     expect(element).toHaveId('by-label-input');

--- a/projects/spectator/src/lib/dom-selectors.ts
+++ b/projects/spectator/src/lib/dom-selectors.ts
@@ -1,11 +1,11 @@
-import { Matcher, MatcherOptions, queries as DOMQueries } from '@testing-library/dom';
+import { Matcher, MatcherOptions, SelectorMatcherOptions, queries as DOMQueries } from '@testing-library/dom';
 
 export class DOMSelector {
   // Wrap selector functions in a class to make reflection easier in getChild
   constructor(public readonly execute: (el: HTMLElement) => HTMLElement[]) {}
 }
 
-export type DOMSelectorFactory = (matcher: Matcher, options?: MatcherOptions) => DOMSelector;
+export type DOMSelectorFactory<TOptions extends MatcherOptions = MatcherOptions> = (matcher: Matcher, options?: TOptions) => DOMSelector;
 
 export const byLabel: DOMSelectorFactory = (matcher, options) =>
   new DOMSelector(el => DOMQueries.queryAllByLabelText(el, matcher, options));
@@ -13,7 +13,8 @@ export const byLabel: DOMSelectorFactory = (matcher, options) =>
 export const byPlaceholder: DOMSelectorFactory = (matcher, options) =>
   new DOMSelector(el => DOMQueries.queryAllByPlaceholderText(el, matcher, options));
 
-export const byText: DOMSelectorFactory = (matcher, options) => new DOMSelector(el => DOMQueries.queryAllByText(el, matcher, options));
+export const byText: DOMSelectorFactory<SelectorMatcherOptions> = (matcher, options) =>
+  new DOMSelector(el => DOMQueries.queryAllByText(el, matcher, options));
 
 export const byAltText: DOMSelectorFactory = (matcher, options) =>
   new DOMSelector(el => DOMQueries.queryAllByAltText(el, matcher, options));

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
@@ -15,6 +15,15 @@ describe('DomSelectorsComponent', () => {
     expect(element).toHaveId('by-text-p');
   });
 
+  it('should allow querying by text and selector', () => {
+    const element = spectator.query(byText('By text', { selector: '#by-text-p-2' }));
+    expect(element).toHaveId('by-text-p-2');
+
+    const elements = spectator.queryAll(byText('By text', { selector: '#by-text-p-2' }));
+    expect(elements[0]).toHaveId('by-text-p-2');
+    expect(elements).toHaveLength(1);
+  });
+
   it('should allow querying by label', () => {
     const element = spectator.query(byLabel('By label'));
     expect(element).toHaveId('by-label-input');

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
   selector: 'app-dom-selectors',
   template: `
     <p id="by-text-p">By text</p>
+    <p id="by-text-p-2">By text</p>
 
     <label for="by-label-input">By label</label>
     <input type="text" id="by-label-input" />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently TS type for `byText` query doesn't allow to specify `selector` option however it's supported by the underlying `@testing-library/dom` module.

## What is the new behavior?

Added support for `selector` option.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```