### PR TITLE
feat(dom-selectors): add `byTextContent` query

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,19 @@ spectator.query(byAltText('By alt text'));
 spectator.query(byLabel('By label'));
 spectator.query(byText('By text'));
 spectator.query(byText('By text', {selector: '#some .selector'}));
+spectator.query(byTextContent('By text content', {selector: '#some .selector'}));
 ```
+
+The difference between `byText` and `byTextContent` is that the former doesn't match text inside a nested elements.
+
+For example, in this following HTML `byText('foobar', {selector: 'div'})` won't match the following `div`, but `byTextContent` will:
+```html
+<div>
+  <span>foo</span>
+  <span>bar</span>
+</div>
+```
+
 #### Testing Select Elements
 Spectator allows you to test `<select></select>` elements easily, and supports multi select.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15715,9 +15715,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/projects/spectator/jest/src/lib/dom-selectors.ts
+++ b/projects/spectator/jest/src/lib/dom-selectors.ts
@@ -1,1 +1,1 @@
-export { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, byTestId } from '@ngneat/spectator';
+export { byAltText, byLabel, byPlaceholder, byText, byTextContent, byTitle, byValue, byTestId } from '@ngneat/spectator';

--- a/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -1,4 +1,14 @@
-import { createComponentFactory, Spectator, byAltText, byLabel, byPlaceholder, byText, byTitle, byValue } from '@ngneat/spectator/jest';
+import {
+  createComponentFactory,
+  Spectator,
+  byAltText,
+  byLabel,
+  byPlaceholder,
+  byText,
+  byTitle,
+  byValue,
+  byTextContent
+} from '@ngneat/spectator/jest';
 
 import { DomSelectorsComponent } from '../../../test/dom-selectors/dom-selectors.component';
 
@@ -47,5 +57,119 @@ describe('DomSelectorsComponent', () => {
   it('should allow querying by value', () => {
     const element = spectator.query(byValue('By value'));
     expect(element).toHaveId('by-value-input');
+  });
+
+  describe('byTextContent', () => {
+    describe('with string matcher', () => {
+      [
+        { description: 'by default', opts: {} },
+        { description: 'with `exact: true`', opts: { exact: true } }
+      ].forEach(({ description, opts }) => {
+        it(`should exactly match text content ${description}`, () => {
+          let element = spectator.query(byTextContent('deeply nested', { selector: '#text-content-root', ...opts }));
+          expect(element).toBeNull();
+          element = spectator.query(byTextContent('some deeply nested text', { selector: '#text-content-root', ...opts }));
+          expect(element).toBeNull();
+          element = spectator.query(byTextContent('some deeply NESTED TEXT', { selector: '#text-content-root', ...opts }));
+          expect(element).toHaveId('text-content-root');
+        });
+      });
+
+      it('should partially match text with `exact: false`', () => {
+        const element = spectator.query(byTextContent('deeply nested', { selector: '#text-content-root', exact: false }));
+        expect(element).toHaveId('text-content-root');
+      });
+
+      it('should support `trim` option', () => {
+        let element = spectator.query(byTextContent('TEXT', { selector: '#text-content-span-2', exact: true, trim: false }));
+        expect(element).toBeNull();
+        element = spectator.query(byTextContent(' TEXT ', { selector: '#text-content-span-2', exact: true, trim: false }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        let element = spectator.query(
+          byTextContent('deeply NESTED', { selector: '#text-content-span-1', exact: true, collapseWhitespace: false })
+        );
+        expect(element).toBeNull();
+        element = spectator.query(
+          byTextContent('deeply  NESTED', { selector: '#text-content-span-1', exact: true, collapseWhitespace: false })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+
+      it('should support custom normalizer', () => {
+        const toLowerCase = (text: string) => text.toLowerCase();
+        let element = spectator.query(
+          byTextContent('deeply  NESTED', { selector: '#text-content-span-1', exact: true, normalizer: toLowerCase })
+        );
+        expect(element).toBeNull();
+        element = spectator.query(
+          byTextContent('deeply  nested', { selector: '#text-content-span-1', exact: true, normalizer: toLowerCase })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+    });
+
+    describe('with RegExp matcher', () => {
+      it('should match the text', () => {
+        const element = spectator.query(byTextContent(/^some deeply NESTED TEXT$/, { selector: '#text-content-root' }));
+        expect(element).toHaveId('text-content-root');
+      });
+
+      it('should support `trim` option', () => {
+        const element = spectator.query(byTextContent(/^ TEXT $/, { selector: '#text-content-span-2', trim: false }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        const element = spectator.query(
+          byTextContent(/^deeply\s\sNESTED$/, { selector: '#text-content-span-1', collapseWhitespace: false })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+
+      it('should support custom normalizer', () => {
+        const toLowerCase = (text: string) => text.toLowerCase();
+        const element = spectator.query(byTextContent(/deeply\s\snested/, { selector: '#text-content-span-1', normalizer: toLowerCase }));
+        expect(element).toHaveId('text-content-span-1');
+      });
+    });
+
+    describe('with function matcher', () => {
+      it('should call matcher for all elements matching the selector', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(false);
+        const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
+        expect(element).toBeNull();
+        expect(matcher).toHaveBeenCalledTimes(2);
+        expect(matcher.calls.argsFor(0)).toEqual(['deeply NESTED', spectator.query('#text-content-span-1')]);
+        expect(matcher.calls.argsFor(1)).toEqual(['TEXT', spectator.query('#text-content-span-2')]);
+      });
+
+      it('should match and element for which matcher returns `true`', () => {
+        const matcher = (text: string) => text === 'TEXT';
+        const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `trim` option', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-2', trim: false }));
+        expect(matcher).toHaveBeenCalledWith(' TEXT ', spectator.query('#text-content-span-2'));
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-1', collapseWhitespace: false }));
+        expect(matcher).toHaveBeenCalledWith('deeply  NESTED', spectator.query('#text-content-span-1'));
+      });
+
+      it('should support custom normalizer', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        const toLowerCase = (text: string) => text.toLowerCase();
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-1', normalizer: toLowerCase }));
+        expect(matcher).toHaveBeenCalledWith('deeply  nested', spectator.query('#text-content-span-1'));
+      });
+    });
   });
 });

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
@@ -1,4 +1,14 @@
-import { byAltText, byLabel, byPlaceholder, byText, byTitle, byValue, createComponentFactory, Spectator } from '@ngneat/spectator';
+import {
+  byAltText,
+  byLabel,
+  byPlaceholder,
+  byText,
+  byTextContent,
+  byTitle,
+  byValue,
+  createComponentFactory,
+  Spectator
+} from '@ngneat/spectator';
 
 import { DomSelectorsComponent } from './dom-selectors.component';
 
@@ -47,5 +57,119 @@ describe('DomSelectorsComponent', () => {
   it('should allow querying by value', () => {
     const element = spectator.query(byValue('By value'));
     expect(element).toHaveId('by-value-input');
+  });
+
+  describe('byTextContent', () => {
+    describe('with string matcher', () => {
+      [
+        { description: 'by default', opts: {} },
+        { description: 'with `exact: true`', opts: { exact: true } }
+      ].forEach(({ description, opts }) => {
+        it(`should exactly match text content ${description}`, () => {
+          let element = spectator.query(byTextContent('deeply nested', { selector: '#text-content-root', ...opts }));
+          expect(element).toBeNull();
+          element = spectator.query(byTextContent('some deeply nested text', { selector: '#text-content-root', ...opts }));
+          expect(element).toBeNull();
+          element = spectator.query(byTextContent('some deeply NESTED TEXT', { selector: '#text-content-root', ...opts }));
+          expect(element).toHaveId('text-content-root');
+        });
+      });
+
+      it('should partially match text with `exact: false`', () => {
+        const element = spectator.query(byTextContent('deeply nested', { selector: '#text-content-root', exact: false }));
+        expect(element).toHaveId('text-content-root');
+      });
+
+      it('should support `trim` option', () => {
+        let element = spectator.query(byTextContent('TEXT', { selector: '#text-content-span-2', exact: true, trim: false }));
+        expect(element).toBeNull();
+        element = spectator.query(byTextContent(' TEXT ', { selector: '#text-content-span-2', exact: true, trim: false }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        let element = spectator.query(
+          byTextContent('deeply NESTED', { selector: '#text-content-span-1', exact: true, collapseWhitespace: false })
+        );
+        expect(element).toBeNull();
+        element = spectator.query(
+          byTextContent('deeply  NESTED', { selector: '#text-content-span-1', exact: true, collapseWhitespace: false })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+
+      it('should support custom normalizer', () => {
+        const toLowerCase = (text: string) => text.toLowerCase();
+        let element = spectator.query(
+          byTextContent('deeply  NESTED', { selector: '#text-content-span-1', exact: true, normalizer: toLowerCase })
+        );
+        expect(element).toBeNull();
+        element = spectator.query(
+          byTextContent('deeply  nested', { selector: '#text-content-span-1', exact: true, normalizer: toLowerCase })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+    });
+
+    describe('with RegExp matcher', () => {
+      it('should match the text', () => {
+        const element = spectator.query(byTextContent(/^some deeply NESTED TEXT$/, { selector: '#text-content-root' }));
+        expect(element).toHaveId('text-content-root');
+      });
+
+      it('should support `trim` option', () => {
+        const element = spectator.query(byTextContent(/^ TEXT $/, { selector: '#text-content-span-2', trim: false }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        const element = spectator.query(
+          byTextContent(/^deeply\s\sNESTED$/, { selector: '#text-content-span-1', collapseWhitespace: false })
+        );
+        expect(element).toHaveId('text-content-span-1');
+      });
+
+      it('should support custom normalizer', () => {
+        const toLowerCase = (text: string) => text.toLowerCase();
+        const element = spectator.query(byTextContent(/deeply\s\snested/, { selector: '#text-content-span-1', normalizer: toLowerCase }));
+        expect(element).toHaveId('text-content-span-1');
+      });
+    });
+
+    describe('with function matcher', () => {
+      it('should call matcher for all elements matching the selector', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(false);
+        const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
+        expect(element).toBeNull();
+        expect(matcher).toHaveBeenCalledTimes(2);
+        expect(matcher.calls.argsFor(0)).toEqual(['deeply NESTED', spectator.query('#text-content-span-1')]);
+        expect(matcher.calls.argsFor(1)).toEqual(['TEXT', spectator.query('#text-content-span-2')]);
+      });
+
+      it('should match and element for which matcher returns `true`', () => {
+        const matcher = (text: string) => text === 'TEXT';
+        const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
+        expect(element).toHaveId('text-content-span-2');
+      });
+
+      it('should support `trim` option', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-2', trim: false }));
+        expect(matcher).toHaveBeenCalledWith(' TEXT ', spectator.query('#text-content-span-2'));
+      });
+
+      it('should support `collapseWhitespace` option', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-1', collapseWhitespace: false }));
+        expect(matcher).toHaveBeenCalledWith('deeply  NESTED', spectator.query('#text-content-span-1'));
+      });
+
+      it('should support custom normalizer', () => {
+        const matcher = jasmine.createSpy('matcher').and.returnValue(true);
+        const toLowerCase = (text: string) => text.toLowerCase();
+        spectator.query(byTextContent(matcher, { selector: '#text-content-span-1', normalizer: toLowerCase }));
+        expect(matcher).toHaveBeenCalledWith('deeply  nested', spectator.query('#text-content-span-1'));
+      });
+    });
   });
 });

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.ts
@@ -16,6 +16,14 @@ import { Component } from '@angular/core';
     <a href="" title="By title" id="by-title-a"></a>
 
     <input type="text" value="By value" id="by-value-input" />
+
+    <div id="text-content-root">
+      <span> some </span>
+      <span>
+        <span id="text-content-span-1"><span>deeply</span><span>&ngsp;</span><span>&ngsp;</span>NESTED</span>
+        <span id="text-content-span-2"> TEXT </span>
+      </span>
+    </div>
   `
 })
 export class DomSelectorsComponent {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: I've also updated Prettier to v1.19.1 in `package-lock.json` (this version still matches the version from `package.json`) because old version didn't support optional chaining operator which I use in this PR.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current `byText` query matches text only in direct element's text nodes and doesn't support nested elements.

For example, `byText('foobar')` won't match `div` in this example:
```html
<div>
  <span>foo</span><span>bar</span>
</div>
```

Issue Number: N/A


## What is the new behavior?

This PR introduces `byTextContent` query that eliminates this restriction. I've made `selector` option mandatory because queries like `byTextContent('foo', {exact: false})` will match the element with text `foo` and all its parents which, I think, will be very confusing is not good.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->