### PR TITLE
feat: add key & keyCode parameter for keyboard events

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ spectator.dispatchMouseEvent(SpectatorElement, 'mouseout'), x, y, event);
 - `dispatchKeyboardEvent()` - Triggers a keyboard event:
 ```ts
 spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', 'Escape');
+spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', { key: 'Escape', keyCode: 27 })
 ```
 - `dispatchTouchEvent()` - Triggers a touch event:
 ```ts

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -1,20 +1,20 @@
-import { ChangeDetectorRef, DebugElement, ElementRef, Type, EventEmitter, InjectionToken, AbstractType } from '@angular/core';
+import { ChangeDetectorRef, DebugElement, ElementRef, Type, EventEmitter } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ComponentFixture, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { Token } from '../token';
 import { DOMSelector } from '../dom-selectors';
-import { isString, QueryOptions, QueryType, SpectatorElement, EventEmitterType, KeysMatching } from '../types';
+import { isString, QueryOptions, QueryType, SpectatorElement, EventEmitterType, KeysMatching, KeyboardEventOptions } from '../types';
 import { SpyObject } from '../mock';
 import { getChildren, setProps } from '../internals/query';
 import { patchElementFocus } from '../internals/element-focus';
 import { createMouseEvent } from '../internals/event-objects';
 import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent, dispatchTouchEvent } from '../dispatch-events';
 import { typeInElement } from '../type-in-element';
+import { selectOption } from '../select-option';
 
 import { BaseSpectator } from './base-spectator';
-import { selectOption } from '../select-option';
 
 const KEY_UP = 'keyup';
 
@@ -179,10 +179,11 @@ export abstract class DomSpectator<I> extends BaseSpectator {
 
   public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyCode: number, target?: Element): KeyboardEvent;
   public dispatchKeyboardEvent(selector: SpectatorElement, type: string, key: string, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyAndCode: KeyboardEventOptions, target?: Element): KeyboardEvent;
   public dispatchKeyboardEvent(
     selector: SpectatorElement = this.element,
     type: string,
-    keyOrKeyCode: string | number,
+    keyOrKeyCode: string | number | KeyboardEventOptions,
     target?: Element
   ): KeyboardEvent {
     const element = this.getNativeElement(selector);
@@ -226,13 +227,13 @@ export abstract class DomSpectator<I> extends BaseSpectator {
         this.dispatchKeyboardEvent(selector, event, key);
       },
       pressEscape: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Escape');
+        this.dispatchKeyboardEvent(selector, event, { key: 'Escape', keyCode: 27 });
       },
       pressEnter: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Enter');
+        this.dispatchKeyboardEvent(selector, event, { key: 'Enter', keyCode: 13 });
       },
       pressTab: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Tab');
+        this.dispatchKeyboardEvent(selector, event, { key: 'Tab', keyCode: 9 });
       },
       pressBackspace: (selector: SpectatorElement = this.element, event = KEY_UP) => {
         this.dispatchKeyboardEvent(selector, event, 'Backspace');

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -236,7 +236,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
         this.dispatchKeyboardEvent(selector, event, { key: 'Tab', keyCode: 9 });
       },
       pressBackspace: (selector: SpectatorElement = this.element, event = KEY_UP) => {
-        this.dispatchKeyboardEvent(selector, event, 'Backspace');
+        this.dispatchKeyboardEvent(selector, event, { key: 'Backspace', keyCode: 8 });
       }
     };
   }

--- a/projects/spectator/src/lib/dispatch-events.ts
+++ b/projects/spectator/src/lib/dispatch-events.ts
@@ -3,6 +3,7 @@
  */
 
 import { createFakeEvent, createKeyboardEvent, createMouseEvent, createTouchEvent } from './internals/event-objects';
+import { KeyboardEventOptions } from './types';
 
 /**
  * Utility to dispatch any event on a Node.
@@ -33,7 +34,12 @@ export function dispatchFakeEvent(node: Node | Window, type: string, canBubble?:
  *
  *  @publicApi
  */
-export function dispatchKeyboardEvent(node: Node, type: string, keyOrKeyCode: string | number, target?: Element): KeyboardEvent {
+export function dispatchKeyboardEvent(
+  node: Node,
+  type: string,
+  keyOrKeyCode: string | number | KeyboardEventOptions,
+  target?: Element
+): KeyboardEvent {
   return dispatchEvent(node, createKeyboardEvent(type, keyOrKeyCode, target));
 }
 

--- a/projects/spectator/src/lib/internals/event-objects.ts
+++ b/projects/spectator/src/lib/internals/event-objects.ts
@@ -3,6 +3,7 @@
  */
 
 import { parseKeyOptions } from './key-parser';
+import { KeyboardEventOptions } from '../types';
 
 /** Creates a browser MouseEvent with the specified options. */
 export function createMouseEvent(type: string, x: number = 0, y: number = 0, button: number = 0): MouseEvent {
@@ -40,7 +41,7 @@ export function createTouchEvent(type: string, pageX: number = 0, pageY: number 
 }
 
 /** Dispatches a keydown event from an element. */
-export function createKeyboardEvent(type: string, keyOrKeyCode: string | number, target?: Element): KeyboardEvent {
+export function createKeyboardEvent(type: string, keyOrKeyCode: string | number | KeyboardEventOptions, target?: Element): KeyboardEvent {
   const { key, keyCode, modifiers } = parseKeyOptions(keyOrKeyCode);
 
   const event = document.createEvent('KeyboardEvent') as any;

--- a/projects/spectator/src/lib/internals/key-parser.ts
+++ b/projects/spectator/src/lib/internals/key-parser.ts
@@ -22,7 +22,7 @@ export const parseKeyOptions = (keyOrKeyCode: string | number | KeyboardEventOpt
     return parseKey(keyOrKeyCode as string);
   }
 
-  if (isObject(keyOrKeyCode) && keyOrKeyCode) {
+  if (isObject(keyOrKeyCode)) {
     const parsedKey = parseKey(keyOrKeyCode.key);
 
     return {

--- a/projects/spectator/src/lib/internals/key-parser.ts
+++ b/projects/spectator/src/lib/internals/key-parser.ts
@@ -1,4 +1,4 @@
-import { isNumber, isString } from '../types';
+import { isNumber, isString, KeyboardEventOptions, isObject } from '../types';
 
 export interface ModifierKeys {
   alt?: boolean;
@@ -13,13 +13,22 @@ export interface KeyOptions {
   modifiers: ModifierKeys;
 }
 
-export const parseKeyOptions = (keyOrKeyCode: string | number): KeyOptions => {
+export const parseKeyOptions = (keyOrKeyCode: string | number | KeyboardEventOptions): KeyOptions => {
   if (isNumber(keyOrKeyCode) && keyOrKeyCode) {
     return { key: false, keyCode: keyOrKeyCode, modifiers: {} };
   }
 
   if (isString(keyOrKeyCode) && keyOrKeyCode) {
     return parseKey(keyOrKeyCode as string);
+  }
+
+  if (isObject(keyOrKeyCode) && keyOrKeyCode) {
+    const parsedKey = parseKey(keyOrKeyCode.key);
+
+    return {
+      ...parsedKey,
+      keyCode: keyOrKeyCode.keyCode
+    };
   }
 
   throw new Error('keyboard.pressKey() requires a valid key or keyCode');

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -24,6 +24,11 @@ export type KeysMatching<T, V> = { [K in keyof T]: T[K] extends V ? K : never }[
 
 export type SelectOptions = string | string[] | HTMLOptionElement | HTMLOptionElement[];
 
+export interface KeyboardEventOptions {
+  key: string;
+  keyCode: number;
+}
+
 export function doesServiceImplementsOnDestroy<S>(testedService: S): testedService is S & OnDestroy {
   return 'ngOnDestroy' in testedService && typeof testedService['ngOnDestroy'] === 'function';
 }

--- a/projects/spectator/test/events/events.component.html
+++ b/projects/spectator/test/events/events.component.html
@@ -4,4 +4,6 @@
        (keyup.control.a)="onPressCtrlA()"
        (keyup.control.shift.a)="onPressCtrlShiftA()"
        (keyup.dot)="onPressDot()"
+       (keyup.arrowleft)="onPressArrowLeft($event)"
+       (keyup.control.shift.arrowright)="onPressArrowRight($event)"
 >

--- a/projects/spectator/test/events/events.component.spec.ts
+++ b/projects/spectator/test/events/events.component.spec.ts
@@ -39,6 +39,16 @@ describe('EventsComponent', () => {
     expect(spectator.query('h1')).toHaveText('pressed dot');
   });
 
+  it('should include key and keyCode when KeyboardEventOptions are passed', () => {
+    spectator.dispatchKeyboardEvent('input', 'keyup', { key: 'ArrowLeft', keyCode: 40 });
+    expect(spectator.query('h1')).toHaveText('pressed ArrowLeft:40');
+  });
+
+  it('should parse modifiers from KeyboardEventOptions.key', () => {
+    spectator.dispatchKeyboardEvent('input', 'keyup', { key: 'ctrl.shift.ArrowRight', keyCode: 39 });
+    expect(spectator.query('h1')).toHaveText('pressed ArrowRight:39');
+  });
+
   it('should fail when the pressKey sequence contains only dots', () => {
     try {
       spectator.keyboard.pressKey('...', 'input');

--- a/projects/spectator/test/events/events.component.ts
+++ b/projects/spectator/test/events/events.component.ts
@@ -31,4 +31,12 @@ export class EventsComponent {
   public onPressDot(): void {
     this.event = 'pressed dot';
   }
+
+  public onPressArrowLeft(event: KeyboardEvent): void {
+    this.event = `pressed ${event.key}:${event.keyCode}`;
+  }
+
+  public onPressArrowRight(event: KeyboardEvent): void {
+    this.event = `pressed ArrowRight:${event.keyCode}`;
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 278


## What is the new behavior?
DomSpectator keyboard events now accept an object with key and keyCode as parameters.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
