### PR TITLE
fix(schematics): get rid of schematics-utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4858,17 +4858,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -6559,13 +6548,6 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
-    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -7882,13 +7864,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -9686,47 +9661,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
-    },
     "genfun": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
@@ -10241,13 +10175,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -14129,37 +14056,6 @@
         "semver": "^5.4.1"
       }
     },
-    "npm-registry-client": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.6.0.tgz",
-      "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.5.2",
-        "graceful-fs": "^4.1.6",
-        "normalize-package-data": "~1.0.1 || ^2.0.0",
-        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-        "npmlog": "2 || ^3.1.0 || ^4.0.0",
-        "once": "^1.3.3",
-        "request": "^2.74.0",
-        "retry": "^0.10.0",
-        "safe-buffer": "^5.1.1",
-        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-        "slide": "^1.1.3",
-        "ssri": "^5.2.4"
-      },
-      "dependencies": {
-        "ssri": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-          "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
     "npm-registry-fetch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.2.tgz",
@@ -14193,19 +14089,6 @@
         "commander": "^2.9.0",
         "npm-path": "^2.0.2",
         "which": "^1.2.10"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -16883,115 +16766,6 @@
         "ajv-keywords": "^3.1.0"
       }
     },
-    "schematics-utilities": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/schematics-utilities/-/schematics-utilities-1.1.3.tgz",
-      "integrity": "sha512-5HnrH+MJkUmK7KfRpA457FY0BZatX2oxNts54P1347xlICCC7KjAh0r2Tue20Xfruw1mS3X5woTxa8od+JsqUA==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/core": "^7.3.6",
-        "@angular-devkit/schematics": "^7.3.6",
-        "npm-registry-client": "^8.5.1",
-        "parse5": "^5.0.0",
-        "rxjs": "^6.4.0",
-        "typescript": "^3.3.3333"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "7.3.9",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-7.3.9.tgz",
-          "integrity": "sha512-SaxD+nKFW3iCBKsxNR7+66J30EexW/y7tm8m5AvUH+GwSAgIj0ZYmRUzFEPggcaLVA4WnE/YWqIXZMJW5dT7gw==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.9.1",
-            "chokidar": "2.0.4",
-            "fast-json-stable-stringify": "2.0.0",
-            "rxjs": "6.3.3",
-            "source-map": "0.7.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-              "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
-          }
-        },
-        "@angular-devkit/schematics": {
-          "version": "7.3.9",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-7.3.9.tgz",
-          "integrity": "sha512-xzROGCYp7aQbeJ3V6YC0MND7wKEAdWqmm/GaCufEk0dDS8ZGe0sQhcM2oBRa2nQqGQNeThFIH51kx+FayrJP0w==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "7.3.9",
-            "rxjs": "6.3.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-              "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
-          }
-        },
-        "ajv": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-          "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "chokidar": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-          "dev": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.2.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "lodash.debounce": "^4.0.8",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.5"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -17261,12 +17035,6 @@
       "version": "0.0.4",
       "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "smart-buffer": {
@@ -20023,16 +19791,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
     },
     "widest-line": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "ng-packagr": "^9.0.0",
     "prettier": "^1.11.1",
     "rxjs": "~6.5.4",
-    "schematics-utilities": "^1.1.1",
     "standard-version": "^4.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",

--- a/projects/spectator/ng-package.json
+++ b/projects/spectator/ng-package.json
@@ -8,7 +8,6 @@
     "@testing-library/dom",
     "jquery",
     "@types/jasmine",
-    "schematics-utilities",
     "replace-in-file"
   ]
 }

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@testing-library/dom": "6.1.0",
     "jquery": "3.4.1",
-    "schematics-utilities": "^1.1.1",
     "replace-in-file": "^4.1.3"
   },
   "peerDependencies": {

--- a/projects/spectator/schematics/package.json
+++ b/projects/spectator/schematics/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.0",
   "schematics": "./src/collection.json",
   "peerDependencies": {
-    "@angular-devkit/core": "^7.3.1",
-    "@angular-devkit/schematics": "^7.3.1",
-    "schematics-utilities": "^1.1.1",
-    "typescript": "~3.1.1"
+    "@angular-devkit/core": ">= 8.0.0",
+    "@angular-devkit/schematics": ">= 8.0.0",
+    "typescript": ">= 2.8.0"
   }
 }


### PR DESCRIPTION
Schematics-utilities package was introduced in 6d74f4f022586794a80281082c93e8252fb5d72a
Usages of this package was removed in 372f848448fd384d04d50d1314736c34e81bd832

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #292 


## What is the new behavior?
schematics-utilities removed from dependencies list

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
