### PR TITLE
feature:🎸 Support DOMSelectors shorthands in Events api

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Spectator helps you get rid of all the boilerplate grunt work, leaving you with 
 
 ## Table of Contents
 
+- [Features](#features)
+- [Table of Contents](#table-of-contents)
 - [Installation](#installation)
   - [NPM](#npm)
   - [Yarn](#yarn)
@@ -198,7 +200,7 @@ it('should work with tick', fakeAsync(() => {
 ```
 
 ### Events API
-Each one of the events can accept a `SpectatorElement` which can be one of the following:
+Each one of the events can accept a `DOMSelector` or `SpectatorElement` which can be one of the following:
 
 ```ts
 type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document;
@@ -209,32 +211,41 @@ If not provided, the default element will be the host element of the component u
 - `click()` - Triggers a click event:
 ```ts
 spectator.click(SpectatorElement);
+spectator.click(DOMSelector);
 ```
 - `blur()` - Triggers a blur event:
 ```ts
 spectator.blur(SpectatorElement);
+spectator.blur(DOMSelector);
 ```
 - `focus()` - Triggers a focus event:
 ```ts
 spectator.focus(SpectatorElement);
+spectator.focus(DOMSelector);
 ```
 - `typeInElement()` - Simulating the user typing:
 ```ts
 spectator.typeInElement(value, SpectatorElement);
+spectator.typeInElement(value, DOMSelector);
 ```
 - `dispatchMouseEvent()` - Triggers a mouse event:
 ```ts
 spectator.dispatchMouseEvent(SpectatorElement, 'mouseout');
 spectator.dispatchMouseEvent(SpectatorElement, 'mouseout'), x, y, event);
+spectator.dispatchMouseEvent(DOMSelector, 'mouseout');
+spectator.dispatchMouseEvent(DOMSelector, 'mouseout'), x, y, event);
 ```
 - `dispatchKeyboardEvent()` - Triggers a keyboard event:
 ```ts
 spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', 'Escape');
 spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', { key: 'Escape', keyCode: 27 })
+spectator.dispatchKeyboardEvent(DOMSelector, 'keyup', 'Escape');
+spectator.dispatchKeyboardEvent(DOMSelector, 'keyup', { key: 'Escape', keyCode: 27 })
 ```
 - `dispatchTouchEvent()` - Triggers a touch event:
 ```ts
 spectator.dispatchTouchEvent(SpectatorElement, type, x, y);
+spectator.dispatchTouchEvent(DOMSelector, type, x, y);
 ```
 
 #### Custom Events

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Spectator helps you get rid of all the boilerplate grunt work, leaving you with 
 
 ## Table of Contents
 
-- [Features](#features)
-- [Table of Contents](#table-of-contents)
 - [Installation](#installation)
   - [NPM](#npm)
   - [Yarn](#yarn)
@@ -200,10 +198,10 @@ it('should work with tick', fakeAsync(() => {
 ```
 
 ### Events API
-Each one of the events can accept a `DOMSelector` or `SpectatorElement` which can be one of the following:
+Each one of the events can accept a `SpectatorElement` which can be one of the following:
 
 ```ts
-type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document;
+type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document | DOMSelector;
 ```
 
 If not provided, the default element will be the host element of the component under test.
@@ -211,41 +209,41 @@ If not provided, the default element will be the host element of the component u
 - `click()` - Triggers a click event:
 ```ts
 spectator.click(SpectatorElement);
-spectator.click(DOMSelector);
+spectator.click(byText('Element'));
 ```
 - `blur()` - Triggers a blur event:
 ```ts
 spectator.blur(SpectatorElement);
-spectator.blur(DOMSelector);
+spectator.blur(byText('Element'));
 ```
 - `focus()` - Triggers a focus event:
 ```ts
 spectator.focus(SpectatorElement);
-spectator.focus(DOMSelector);
+spectator.focus(byText('Element'));
 ```
 - `typeInElement()` - Simulating the user typing:
 ```ts
 spectator.typeInElement(value, SpectatorElement);
-spectator.typeInElement(value, DOMSelector);
+spectator.typeInElement(value, byText('Element'));
 ```
 - `dispatchMouseEvent()` - Triggers a mouse event:
 ```ts
 spectator.dispatchMouseEvent(SpectatorElement, 'mouseout');
 spectator.dispatchMouseEvent(SpectatorElement, 'mouseout'), x, y, event);
-spectator.dispatchMouseEvent(DOMSelector, 'mouseout');
-spectator.dispatchMouseEvent(DOMSelector, 'mouseout'), x, y, event);
+spectator.dispatchMouseEvent(byText('Element'), 'mouseout');
+spectator.dispatchMouseEvent(byText('Element'), 'mouseout'), x, y, event);
 ```
 - `dispatchKeyboardEvent()` - Triggers a keyboard event:
 ```ts
 spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', 'Escape');
 spectator.dispatchKeyboardEvent(SpectatorElement, 'keyup', { key: 'Escape', keyCode: 27 })
-spectator.dispatchKeyboardEvent(DOMSelector, 'keyup', 'Escape');
-spectator.dispatchKeyboardEvent(DOMSelector, 'keyup', { key: 'Escape', keyCode: 27 })
+spectator.dispatchKeyboardEvent(byText('Element'), 'keyup', 'Escape');
+spectator.dispatchKeyboardEvent(byText('Element'), 'keyup', { key: 'Escape', keyCode: 27 })
 ```
 - `dispatchTouchEvent()` - Triggers a touch event:
 ```ts
 spectator.dispatchTouchEvent(SpectatorElement, type, x, y);
-spectator.dispatchTouchEvent(DOMSelector, type, x, y);
+spectator.dispatchTouchEvent(byText('Element'), type, x, y);
 ```
 
 #### Custom Events

--- a/projects/spectator/jest/test/click/click.component.spec.ts
+++ b/projects/spectator/jest/test/click/click.component.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync } from '@angular/core/testing';
-import { byText, createComponentFactory, Spectator } from '@ngneat/spectator';
-import { ClickComponent } from './click.component';
+import { byText, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { ClickComponent } from '../../../test/click/click.component';
 
 describe('ClickComponent', () => {
   let component: ClickComponent;

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -123,7 +123,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public click(selector: SpectatorElement | DOMSelector = this.element): void {
+  public click(selector: SpectatorElement = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -134,7 +134,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public blur(selector: SpectatorElement | DOMSelector = this.element): void {
+  public blur(selector: SpectatorElement = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -146,7 +146,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public focus(selector: SpectatorElement | DOMSelector = this.element): void {
+  public focus(selector: SpectatorElement = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -159,7 +159,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   }
 
   public dispatchMouseEvent(
-    selector: SpectatorElement | DOMSelector = this.element,
+    selector: SpectatorElement = this.element,
     type: string,
     x: number = 0,
     y: number = 0,
@@ -177,16 +177,11 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return dispatchedEvent;
   }
 
-  public dispatchKeyboardEvent(selector: SpectatorElement | DOMSelector, type: string, keyCode: number, target?: Element): KeyboardEvent;
-  public dispatchKeyboardEvent(selector: SpectatorElement | DOMSelector, type: string, key: string, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyCode: number, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, key: string, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyAndCode: KeyboardEventOptions, target?: Element): KeyboardEvent;
   public dispatchKeyboardEvent(
-    selector: SpectatorElement | DOMSelector,
-    type: string,
-    keyAndCode: KeyboardEventOptions,
-    target?: Element
-  ): KeyboardEvent;
-  public dispatchKeyboardEvent(
-    selector: SpectatorElement | DOMSelector = this.element,
+    selector: SpectatorElement = this.element,
     type: string,
     keyOrKeyCode: string | number | KeyboardEventOptions,
     target?: Element
@@ -204,7 +199,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return event;
   }
 
-  public dispatchFakeEvent(selector: SpectatorElement | DOMSelector = this.element, type: string, canBubble?: boolean): Event {
+  public dispatchFakeEvent(selector: SpectatorElement = this.element, type: string, canBubble?: boolean): Event {
     const event = dispatchFakeEvent(this.getNativeElement(selector), type, canBubble);
     this.detectChanges();
 
@@ -257,18 +252,18 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     };
   }
 
-  public dispatchTouchEvent(selector: SpectatorElement | DOMSelector = this.element, type: string, x: number = 0, y: number = 0): void {
+  public dispatchTouchEvent(selector: SpectatorElement = this.element, type: string, x: number = 0, y: number = 0): void {
     dispatchTouchEvent(this.getNativeElement(selector), type, x, y);
     this.detectChanges();
   }
 
-  public typeInElement(value: string, selector: SpectatorElement | DOMSelector = this.element): void {
+  public typeInElement(value: string, selector: SpectatorElement = this.element): void {
     typeInElement(value, this.getNativeElement(selector));
     this.detectChanges();
   }
 
   public selectOption(
-    selector: SpectatorElement | DOMSelector = this.element,
+    selector: SpectatorElement = this.element,
     options: string | string[] | HTMLOptionElement | HTMLOptionElement[],
     config: { emitEvents: boolean } = { emitEvents: true }
   ): void {
@@ -279,7 +274,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  private getNativeElement(selector: SpectatorElement | DOMSelector): HTMLElement | Window | Document {
+  private getNativeElement(selector: SpectatorElement): HTMLElement | Window | Document {
     let element;
 
     // Support global objects window and document

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -123,7 +123,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public click(selector: SpectatorElement = this.element): void {
+  public click(selector: SpectatorElement | DOMSelector = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -134,7 +134,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public blur(selector: SpectatorElement = this.element): void {
+  public blur(selector: SpectatorElement | DOMSelector = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -146,7 +146,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  public focus(selector: SpectatorElement = this.element): void {
+  public focus(selector: SpectatorElement | DOMSelector = this.element): void {
     const element = this.getNativeElement(selector);
 
     if (!(element instanceof HTMLElement)) {
@@ -159,7 +159,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   }
 
   public dispatchMouseEvent(
-    selector: SpectatorElement = this.element,
+    selector: SpectatorElement | DOMSelector = this.element,
     type: string,
     x: number = 0,
     y: number = 0,
@@ -177,11 +177,16 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return dispatchedEvent;
   }
 
-  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyCode: number, target?: Element): KeyboardEvent;
-  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, key: string, target?: Element): KeyboardEvent;
-  public dispatchKeyboardEvent(selector: SpectatorElement, type: string, keyAndCode: KeyboardEventOptions, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement | DOMSelector, type: string, keyCode: number, target?: Element): KeyboardEvent;
+  public dispatchKeyboardEvent(selector: SpectatorElement | DOMSelector, type: string, key: string, target?: Element): KeyboardEvent;
   public dispatchKeyboardEvent(
-    selector: SpectatorElement = this.element,
+    selector: SpectatorElement | DOMSelector,
+    type: string,
+    keyAndCode: KeyboardEventOptions,
+    target?: Element
+  ): KeyboardEvent;
+  public dispatchKeyboardEvent(
+    selector: SpectatorElement | DOMSelector = this.element,
     type: string,
     keyOrKeyCode: string | number | KeyboardEventOptions,
     target?: Element
@@ -199,7 +204,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return event;
   }
 
-  public dispatchFakeEvent(selector: SpectatorElement = this.element, type: string, canBubble?: boolean): Event {
+  public dispatchFakeEvent(selector: SpectatorElement | DOMSelector = this.element, type: string, canBubble?: boolean): Event {
     const event = dispatchFakeEvent(this.getNativeElement(selector), type, canBubble);
     this.detectChanges();
 
@@ -252,18 +257,18 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     };
   }
 
-  public dispatchTouchEvent(selector: SpectatorElement = this.element, type: string, x: number = 0, y: number = 0): void {
+  public dispatchTouchEvent(selector: SpectatorElement | DOMSelector = this.element, type: string, x: number = 0, y: number = 0): void {
     dispatchTouchEvent(this.getNativeElement(selector), type, x, y);
     this.detectChanges();
   }
 
-  public typeInElement(value: string, selector: SpectatorElement = this.element): void {
+  public typeInElement(value: string, selector: SpectatorElement | DOMSelector = this.element): void {
     typeInElement(value, this.getNativeElement(selector));
     this.detectChanges();
   }
 
   public selectOption(
-    selector: SpectatorElement = this.element,
+    selector: SpectatorElement | DOMSelector = this.element,
     options: string | string[] | HTMLOptionElement | HTMLOptionElement[],
     config: { emitEvents: boolean } = { emitEvents: true }
   ): void {
@@ -274,7 +279,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     this.detectChanges();
   }
 
-  private getNativeElement(selector: SpectatorElement): HTMLElement | Window | Document {
+  private getNativeElement(selector: SpectatorElement | DOMSelector): HTMLElement | Window | Document {
     let element;
 
     // Support global objects window and document
@@ -290,6 +295,8 @@ export abstract class DomSpectator<I> extends BaseSpectator {
         // tslint:disable:no-console
         console.error(`${selector} does not exists`);
       }
+    } else if (selector instanceof DOMSelector) {
+      element = selector.execute(document as any)[0] || null;
     } else {
       if (selector instanceof DebugElement || selector instanceof ElementRef) {
         element = selector.nativeElement;

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -10,7 +10,7 @@ type OptionalProperties<T> = Pick<T, OptionalPropertyNames<T>>;
 
 export type OptionalsRequired<T> = Required<OptionalProperties<T>> & Partial<T>;
 
-export type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document;
+export type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document | DOMSelector;
 
 export type QueryType = Type<any> | DOMSelector | string;
 export interface QueryOptions<R> {

--- a/projects/spectator/test/calc/calc.component.spec.ts
+++ b/projects/spectator/test/calc/calc.component.spec.ts
@@ -1,23 +1,31 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator';
-
+import { byLabel, createComponentFactory, Spectator } from '@ngneat/spectator';
 import { CalcComponent } from './calc.component';
 
 describe('CalcComponent', () => {
   let spectator: Spectator<CalcComponent>;
   const createComponent = createComponentFactory(CalcComponent);
 
-  it('should be defined', () => {
+  beforeEach(() => {
     spectator = createComponent();
+  });
+
+  it('should be defined', () => {
     expect(spectator.component).toBeTruthy();
   });
 
   it('should calc the value', () => {
-    spectator = createComponent();
     const a = spectator.query('.a') as HTMLInputElement;
     const b = spectator.query('.b') as HTMLInputElement;
     spectator.typeInElement('1', a);
     spectator.typeInElement('2', b);
 
     expect(spectator.query('.result')).toHaveText('12');
+  });
+
+  it('should calc the value by DOMSelector', () => {
+    spectator.typeInElement('3', byLabel('a'));
+    spectator.typeInElement('7', byLabel('b'));
+
+    expect(spectator.query('.result')).toHaveText('37');
   });
 });

--- a/projects/spectator/test/calc/calc.component.ts
+++ b/projects/spectator/test/calc/calc.component.ts
@@ -3,8 +3,14 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-calc',
   template: `
-    <input type="text" #a class="a" />
-    <input type="text" #b class="b" />
+    <label>
+      <input type="text" #a class="a" />
+      <span>a</span>
+    </label>
+    <label>
+      <input type="text" #b class="b" />
+      <span>b</span>
+    </label>
     <p class="result">{{ a.value + b.value }}</p>
   `
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Add support of DOMSelector shorthand in Events API

Before DOMSelectors should be wrapper in a query function `spectator.click(spectator.query(byText('Submit')))` and with this changes it can be used in shorthand format ``spectator.click(byText('Submit'))``

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
