### PR TITLE
feat: downlevel .d.ts for older TS versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8109,6 +8109,24 @@
         }
       }
     },
+    "downlevel-dts": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.5.0.tgz",
+      "integrity": "sha512-hGikqjcnlkDXqga55u/jQx0ZdQz9Q3LtSqyceHSYavWOmSUoVUGjWZ/zwfiVMFL8rl+LKvJn9L5uaAq7P7xMNA==",
+      "dev": true,
+      "requires": {
+        "shelljs": "^0.8.3",
+        "typescript": "^3.8.0-dev.20200111"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+          "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+          "dev": true
+        }
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -10770,6 +10788,12 @@
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -16064,6 +16088,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -16989,6 +17022,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "ngcc",
     "ng": "ng",
-    "build": "ng build --prod && npm run build:schematics && npm run copy:schematics && npm run copy:docs && npm run copy:bin",
+    "build": "ng build --prod && npm run build:schematics && npm run copy:schematics && npm run copy:docs && npm run copy:bin && npm run downlevel-dts",
     "build:schematics": "tsc -p projects/spectator/schematics/tsconfig.json",
     "test": "ng test",
     "test:jest": "ng run spectator:test-jest",
@@ -20,6 +20,7 @@
     "copy:bin": "cp migrate.js dist/spectator",
     "copy:docs": "cp *.md dist/spectator",
     "copy:schematics": "cp -r projects/spectator/schematics/src/ dist/spectator/schematics",
+    "downlevel-dts": "downlevel-dts ./dist/spectator ./dist/spectator/ts3.4",
     "postbump": "npm run build",
     "release": "cd projects/spectator && standard-version --infile ../../CHANGELOG.md"
   },
@@ -30,7 +31,6 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "git-cz": "^3.2.1",
     "@angular-builders/jest": "^8.0.4",
     "@angular-devkit/build-angular": "~0.900.1",
     "@angular-devkit/build-ng-packagr": "~0.900.1",
@@ -57,6 +57,8 @@
     "core-js": "^2.5.4",
     "cross-env": "^5.1.4",
     "cz-conventional-changelog": "^2.1.0",
+    "downlevel-dts": "^0.5.0",
+    "git-cz": "^3.2.1",
     "helpful-decorators": "^1.7.2",
     "husky": "^0.14.3",
     "jasmine-core": "~3.5.0",

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -36,5 +36,8 @@
   "bin": {
     "spectator-migrate": "./migrate.js"
   },
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+  "typesVersions": {
+    "<3.7": { "*": ["ts3.4/*"] }
+  }
 }


### PR DESCRIPTION
allows to use spectator 5.x with Angular 8 with TS 3.5

Signed-off-by: Andrey Chalkin <L2jLiga@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Angular 8 with TS 3.5 tests fails due to TS errors like

```
node_modules/@ngneat/spectator/lib/spectator/spectator.d.ts:15:9 - error TS1086: An accessor cannot be declared in an ambient context.

15    get component(): C;
```

Issue Number: N/A


## What is the new behavior?

`.d.ts` are downleveled to build without any errors

`get component(): C;` -> `readonly component: C;` (accessors were added in TS 3.6)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
