### PR TITLE
feat: support jest-circus

### DIFF
--- a/projects/spectator/jest/src/lib/spectator-directive.ts
+++ b/projects/spectator/jest/src/lib/spectator-directive.ts
@@ -1,4 +1,4 @@
-import { Type, InjectionToken, AbstractType } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   createDirectiveFactory as baseCreateDirectiveFactory,
   isType,
@@ -18,6 +18,7 @@ export class SpectatorDirective<D, H = HostComponent> extends BaseSpectatorDirec
   /**
    * @deprecated Deprecated in favour of inject(). Will be removed once TestBed.get is discontinued.
    * @param type Token
+   * @param fromComponentInjector
    */
   public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
     return super.get(type, fromComponentInjector) as SpyObject<T>;

--- a/projects/spectator/jest/src/lib/spectator-host.ts
+++ b/projects/spectator/jest/src/lib/spectator-host.ts
@@ -1,4 +1,4 @@
-import { Type, InjectionToken, AbstractType } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   createHostFactory as baseCreateHostFactory,
   isType,
@@ -23,6 +23,7 @@ export class SpectatorHost<C, H = HostComponent> extends BaseSpectatorHost<C, H>
   /**
    * @deprecated Deprecated in favour of inject(). Will be removed once TestBed.get is discontinued.
    * @param type Token
+   * @param fromComponentInjector
    */
   public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
     return super.get(type, fromComponentInjector) as SpyObject<T>;

--- a/projects/spectator/jest/src/lib/spectator-http.ts
+++ b/projects/spectator/jest/src/lib/spectator-http.ts
@@ -1,4 +1,4 @@
-import { Type, InjectionToken, AbstractType } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   createHttpFactory as baseCreateHttpFactory,
   isType,
@@ -17,7 +17,7 @@ import { mockProvider, SpyObject } from './mock';
 export interface SpectatorHttp<S> extends BaseSpectatorHttp<S> {
   /**
    * @deprecated Deprecated in favour of inject(). Will be removed once TestBed.get is discontinued.
-   * @param type Token
+   * @param token
    */
   get<T>(token: Token<T> | Token<any>): SpyObject<T>;
   inject<T>(token: Token<T>): SpyObject<T>;

--- a/projects/spectator/jest/src/lib/spectator-routing.ts
+++ b/projects/spectator/jest/src/lib/spectator-routing.ts
@@ -1,4 +1,4 @@
-import { Type, InjectionToken, AbstractType } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   createRoutingFactory as baseCreateRoutingFactory,
   isType,
@@ -17,6 +17,7 @@ export class SpectatorRouting<C> extends BaseSpectatorRouting<C> {
   /**
    * @deprecated Deprecated in favour of inject(). Will be removed once TestBed.get is discontinued.
    * @param type Token
+   * @param fromComponentInjector
    */
   public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
     return super.get(type, fromComponentInjector) as SpyObject<T>;

--- a/projects/spectator/jest/src/lib/spectator.ts
+++ b/projects/spectator/jest/src/lib/spectator.ts
@@ -1,4 +1,4 @@
-import { Type, InjectionToken, AbstractType } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   createComponentFactory as baseCreateComponentFactory,
   isType,
@@ -33,6 +33,7 @@ export class Spectator<C> extends BaseSpectator<C> {
   /**
    * @deprecated Deprecated in favour of inject(). Will be removed once TestBed.get is discontinued.
    * @param type Token
+   * @param fromComponentInjector
    */
   public get<T>(type: Token<T> | Token<any>, fromComponentInjector: boolean = false): SpyObject<T> {
     return super.get(type, fromComponentInjector) as SpyObject<T>;

--- a/projects/spectator/src/lib/core.ts
+++ b/projects/spectator/src/lib/core.ts
@@ -1,0 +1,20 @@
+import { CustomMatcherFactory } from './matchers';
+
+declare var jasmine: any;
+declare var jest: any;
+
+export function addMatchers(matchers: Record<string, CustomMatcherFactory>): void {
+  if (!matchers) return;
+
+  if (typeof jasmine !== 'undefined') {
+    jasmine.addMatchers(matchers);
+  }
+  if (typeof jest !== 'undefined') {
+    const jestExpectExtend = {};
+    for (const key of Object.keys(matchers)) {
+      if (key.startsWith('to')) jestExpectExtend[key] = matchers[key]().compare;
+    }
+
+    (expect as any).extend(jestExpectExtend);
+  }
+}

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -7,6 +7,19 @@ import { hex2rgb, isHex, trim } from './internals/rgb-to-hex';
 import { isHTMLOptionElementArray, isObject } from './types';
 import { isRunningInJsDom } from './utils';
 
+export interface CustomMatcherFactory {
+  (): CustomMatcher;
+}
+
+export interface CustomMatcher {
+  compare<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
+}
+
+export interface CustomMatcherResult {
+  pass: boolean;
+  message(): string;
+}
+
 const hasProperty = (actual: unknown, expected: unknown): boolean => {
   return expected === undefined ? actual !== undefined : actual === expected;
 };
@@ -98,7 +111,7 @@ const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string)
   return { pass, message };
 };
 
-const comparator = func => () => ({
+const comparator = (func): CustomMatcherFactory => () => ({
   compare: func
 });
 

--- a/projects/spectator/src/lib/spectator-directive/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-directive/create-factory.ts
@@ -5,6 +5,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 
 import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
+import { addMatchers } from '../core';
 import { isType } from '../types';
 import { HostComponent } from '../spectator-host/host-component';
 import { BaseSpectatorOverrides } from '../base/options';
@@ -63,7 +64,7 @@ export function createDirectiveFactory<D, H = HostComponent>(
   const moduleMetadata = initialSpectatorDirectiveModule<D, H>(options);
 
   beforeEach(async(() => {
-    jasmine.addMatchers(customMatchers as any);
+    addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
     overrideModules(options);
   }));

--- a/projects/spectator/src/lib/spectator-host/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-host/create-factory.ts
@@ -6,6 +6,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { overrideComponentIfProviderOverridesSpecified, overrideModules, SpectatorOverrides } from '../spectator/create-factory';
+import { addMatchers } from '../core';
 import { isType } from '../types';
 import { nodeByDirective } from '../internals/node-by-directive';
 
@@ -64,7 +65,7 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
   const moduleMetadata = initialSpectatorWithHostModule<C, H>(options);
 
   beforeEach(async(() => {
-    jasmine.addMatchers(customMatchers as any);
+    addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
 
     overrideModules(options);

--- a/projects/spectator/src/lib/spectator-pipe/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-pipe/create-factory.ts
@@ -5,6 +5,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { BaseSpectatorOverrides } from '../base/options';
+import { addMatchers } from '../core';
 import { isType } from '../types';
 import { HostComponent } from '../spectator-host/host-component';
 
@@ -40,7 +41,7 @@ export function createPipeFactory<P, H = HostComponent>(typeOrOptions: Type<P> |
   const moduleMetadata = initialSpectatorPipeModule<P, H>(options);
 
   beforeEach(async(() => {
-    jasmine.addMatchers(customMatchers as any);
+    addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
     overrideModules(options);
   }));

--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import { SpectatorOverrides, overrideComponentIfProviderOverridesSpecified, overrideModules } from '../spectator/create-factory';
+import { addMatchers } from '../core';
 import { isType } from '../types';
 
 import { ActivatedRouteStub } from './activated-route-stub';
@@ -34,7 +35,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
   const moduleMetadata = initialRoutingModule<C>(options);
 
   beforeEach(async(() => {
-    jasmine.addMatchers(customMatchers as any);
+    addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
 
     overrideModules(options);

--- a/projects/spectator/src/lib/spectator/create-factory.ts
+++ b/projects/spectator/src/lib/spectator/create-factory.ts
@@ -5,6 +5,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { BaseSpectatorOptions, BaseSpectatorOverrides } from '../base/options';
 import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
+import { addMatchers } from '../core';
 import { isType } from '../types';
 
 import { initialSpectatorModule } from './initial-module';
@@ -80,7 +81,7 @@ export function createComponentFactory<C>(typeOrOptions: Type<C> | SpectatorOpti
   const moduleMetadata = initialSpectatorModule<C>(options);
 
   beforeEach(async(() => {
-    jasmine.addMatchers(customMatchers as any);
+    addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata).overrideModule(BrowserDynamicTestingModule, {
       set: {
         entryComponents: moduleMetadata.entryComponents

--- a/projects/spectator/test/form-select/form-select.component.spec.ts
+++ b/projects/spectator/test/form-select/form-select.component.spec.ts
@@ -1,7 +1,5 @@
 import { ReactiveFormsModule } from '@angular/forms';
-import { Spectator, createComponentFactory } from '@ngneat/spectator';
-
-import { byText } from '../../src/public_api';
+import { Spectator, byText, createComponentFactory } from '@ngneat/spectator';
 
 import { FormSelectComponent } from './form-select.component';
 


### PR DESCRIPTION
Created generic `addMatchers` function which will handle Jasmine vs Jest ways

Signed-off-by: Andrey Chalkin <L2jLiga@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #314 


## What is the new behavior?

Use [`expect.extend`]() from Jest to add custom matchers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
