### PR TITLE
fix(routing): fix 'Navigation triggered outside Angular Zone' warning

### DIFF
--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -1,4 +1,4 @@
-import { Provider, Type } from '@angular/core';
+import { Provider, Type, NgZone } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -65,16 +65,18 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
     TestBed.overrideProvider(ActivatedRoute, {
       useValue: new ActivatedRouteStub({ params, queryParams, data, fragment, url, root, parent, children, firstChild })
     });
+    const ngZone = new NgZone({ enableLongStackTrace: false });
+    return ngZone.run(() => {
+      const spectator = createSpectatorRouting(options, props);
 
-    const spectator = createSpectatorRouting(options, props);
+      spectator.router.initialNavigation();
 
-    spectator.router.initialNavigation();
+      if (options.detectChanges && detectChanges) {
+        spectator.detectChanges();
+      }
 
-    if (options.detectChanges && detectChanges) {
-      spectator.detectChanges();
-    }
-
-    return spectator;
+      return spectator;
+    });
   };
 }
 

--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -65,7 +65,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
     TestBed.overrideProvider(ActivatedRoute, {
       useValue: new ActivatedRouteStub({ params, queryParams, data, fragment, url, root, parent, children, firstChild })
     });
-    const ngZone = new NgZone({ enableLongStackTrace: false });
+    const ngZone = TestBed.get(NgZone);
     return ngZone.run(() => {
       const spectator = createSpectatorRouting(options, props);
 

--- a/projects/spectator/test/with-routing/my-page.component.spec.ts
+++ b/projects/spectator/test/with-routing/my-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { NavigationStart, Router, RouterLink, UrlSegment } from '@angular/router';
 import { createRoutingFactory, ActivatedRouteStub } from '@ngneat/spectator';
-import { Component } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 import { Location } from '@angular/common';
 
 import { MyPageComponent } from './my-page.component';
@@ -165,10 +165,15 @@ describe('MyPageComponent', () => {
       await spectator.fixture.whenStable();
       expect(spectator.inject(Location).path()).toBe('/');
 
-      await spectator.router.navigate(['/foo']);
+      const ngZone = new NgZone({ enableLongStackTrace: false });
+      await ngZone.run(async () => {
+        await spectator.router.navigate(['/foo']);
+      });
       expect(spectator.inject(Location).path()).toBe('/foo');
 
-      await spectator.router.navigate(['/']);
+      await ngZone.run(async () => {
+        await spectator.router.navigate(['/']);
+      });
       expect(spectator.inject(Location).path()).toBe('/');
     });
 

--- a/projects/spectator/test/with-routing/my-page.component.spec.ts
+++ b/projects/spectator/test/with-routing/my-page.component.spec.ts
@@ -4,6 +4,7 @@ import { Component, NgZone } from '@angular/core';
 import { Location } from '@angular/common';
 
 import { MyPageComponent } from './my-page.component';
+import { TestBed } from '@angular/core/testing';
 
 describe('MyPageComponent', () => {
   describe('simple use', () => {
@@ -165,7 +166,7 @@ describe('MyPageComponent', () => {
       await spectator.fixture.whenStable();
       expect(spectator.inject(Location).path()).toBe('/');
 
-      const ngZone = new NgZone({ enableLongStackTrace: false });
+      const ngZone = TestBed.get(NgZone);
       await ngZone.run(async () => {
         await spectator.router.navigate(['/foo']);
       });


### PR DESCRIPTION
wrap createSpectatorRouting in ngZone
run `router.navigate` in spec file in ngZone

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Navigation causes the following warning:

`WARN: 'Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?'`

Issue Number: #298 

## What is the new behavior?

No more warnings by wrapping navigation related functionality in Angular zone.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
