### PR TITLE
Make installProtoMethods function declare properties configurable

### DIFF
--- a/projects/spectator/karma.conf.js
+++ b/projects/spectator/karma.conf.js
@@ -31,6 +31,6 @@ module.exports = function(config) {
     autoWatch: true,
     browsers: [build ? 'ChromeHeadless' : 'Chrome'],
     singleRun: build,
-    restartOnFileChange: true,
+    restartOnFileChange: true
   });
 };

--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -56,7 +56,8 @@ export function installProtoMethods<T>(mock: any, proto: any, createSpyFn: Funct
     } else if (descriptor.get && !mock.hasOwnProperty(key)) {
       Object.defineProperty(mock, key, {
         set: value => (mock[`_${key}`] = value),
-        get: () => mock[`_${key}`]
+        get: () => mock[`_${key}`],
+        configurable: true
       });
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[**X**] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Running karma-jasmine tests under the project (ng10, es2015) will cause failure when trying to use
spyOnProperty() with the service previously mocked by spectator. It's very hard-to-trace issue we ran into.
```
Failed: <spyOnProperty> : "xxx" is not declared configurable
```
jasmine spyOnProperty fails when trying to mock properties which weren't declared as configurable

```
Object.defineProperty(mock, key, {
        set: value => (mock[`_${key}`] = value),
        get: () => mock[`_${key}`],
        **configurable: true**
      });
```

Issue Number: N/A

## What is the new behavior?

Using ``mocks`` option or ``mockProvider`` function will create a mock object of type and declare all properties of type as configurable, so it will be possible to spy on them using jasmine tools

## Does this PR introduce a breaking change?
```
[ ] Yes
[**X**] No
```

## Other information
