### PR TITLE
fix(component-host): setting for wrong variable

### DIFF
--- a/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
@@ -21,7 +21,7 @@ describe('<%= classify(name)%>Component', () => {
   it('should...', () => {
     spectator = createHost(`<zippy title="Zippy title"></zippy>`);
     spectator.click('.zippy__title');
-    expect(host.query('.zippy__content')).toExist();
+    expect(spectator.query('.zippy__content')).toExist();
     spectator.click('.zippy__title');
     expect('.zippy__content').not.toExist();
   });

--- a/projects/spectator/schematics/src/spectator/files/data-service/__name@dasherize__.service.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/data-service/__name@dasherize__.service.spec.ts
@@ -1,4 +1,4 @@
-import { createHttpFactory, HttpMethod } from '@ngneat/spectator';
+import { createHttpFactory, HttpMethod, SpectatorHttp } from '@ngneat/spectator';
 import { <%= classify(name)%>Service } from './<%= dasherize(name)%>.service';
 
 describe('<%= classify(name)%>Service', () => {


### PR DESCRIPTION
was declaring spectator but using host

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
component-host schematics was declaring spectator but using host
Issue Number: N/A


## What is the new behavior?
just fix that detail

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I believe that contributing can be more friendly, let's make it more explanatory about the flow.

I had to use --no-verify on the commit, because the schematics don't use the .template suffix, I didn't find which tests are testing which schematics / service. if someone helps me we can improve the contribution document:)