### PR TITLE
feat: support run ngOnChanges hook for change bingins (#348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ const service = spectator.inject(QueryService, fromComponentInjector);
 ```ts
 spectator.detectChanges();
 ```
-- `setInput()` - Changes the value of an @Input() of the tested component:
+- `setInput()` - Changes the value of an @Input() of the tested component.
+  Method runs `ngOnChanges` with `SimpleChanges` manually if it exists.
 ```ts
 it('should...', () => {
   spectator.setInput('className', 'danger');

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -96,7 +96,7 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   public setInput<K extends keyof I>(input: Partial<I>): void;
   public setInput<K extends keyof I>(input: K, inputValue: I[K]): void;
   public setInput(input: any, value?: any): void {
-    setProps(this.instance, input, value);
+    setProps(this.instance, input, value, false);
     this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
   }
 

--- a/projects/spectator/src/lib/spectator-directive/spectator-directive.ts
+++ b/projects/spectator/src/lib/spectator-directive/spectator-directive.ts
@@ -36,7 +36,7 @@ export class SpectatorDirective<D, H = HostComponent> extends DomSpectator<D> {
   public setHostInput<K extends keyof H>(input: Partial<H>): void;
   public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
   public setHostInput(input: any, value?: any): void {
-    setProps(this.hostComponent, input, value);
+    setProps(this.hostComponent, input, value, false);
     this.detectChanges();
   }
 }

--- a/projects/spectator/src/lib/spectator-host/spectator-host.ts
+++ b/projects/spectator/src/lib/spectator-host/spectator-host.ts
@@ -50,7 +50,7 @@ export class SpectatorHost<C, H = HostComponent> extends Spectator<C> {
   public setHostInput<K extends keyof H>(input: Partial<H>): void;
   public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
   public setHostInput(input: any, value?: any): void {
-    setProps(this.hostComponent, input, value);
+    setProps(this.hostComponent, input, value, false);
     this.detectChanges();
   }
 }

--- a/projects/spectator/src/lib/spectator-pipe/spectator-pipe.ts
+++ b/projects/spectator/src/lib/spectator-pipe/spectator-pipe.ts
@@ -20,7 +20,7 @@ export class SpectatorPipe<P, H = HostComponent> extends BaseSpectator {
   public setHostInput<K extends keyof H>(input: Partial<H>): void;
   public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
   public setHostInput(input: any, value?: any): void {
-    setProps(this.hostComponent, input, value);
+    setProps(this.hostComponent, input, value, false);
     this.detectChanges();
   }
 }

--- a/projects/spectator/test/simple-changes/simple-changes.component.spec.ts
+++ b/projects/spectator/test/simple-changes/simple-changes.component.spec.ts
@@ -1,0 +1,54 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { CommonModule } from '@angular/common';
+
+import { SimpleChangesComponent } from './simple-changes.component';
+
+describe('SimpleChangesComponent', () => {
+  let spectator: Spectator<SimpleChangesComponent>;
+
+  const createComponent = createComponentFactory({
+    component: SimpleChangesComponent,
+    imports: [CommonModule]
+  });
+
+  it('should be sequence of calls is correct', () => {
+    spectator = createComponent({
+      props: { value: '1' }
+    });
+
+    const { hooks } = spectator.component;
+
+    expect(hooks.length).toBe(2);
+    expect(hooks[0]).toBe('ngOnChanges');
+    expect(hooks[1]).toBe('ngOnInit');
+  });
+
+  it('should be set first change value and next updates', () => {
+    spectator = createComponent({ props: { value: '1' } });
+
+    const { changes } = spectator.component;
+
+    expect(changes.length).toBe(1, 'size after compile');
+    expect(changes[0].currentValue).toBe('1', 'first change currentValue');
+    expect(changes[0].previousValue).toBe(undefined, 'first change previousValue');
+    expect(changes[0].firstChange).toBe(true, 'first change firstChange');
+
+    spectator.setInput({ value: '2' });
+
+    expect(changes.length).toBe(2, 'size after update');
+    expect(changes[1].currentValue).toBe('2', 'after update currentValue');
+    expect(changes[1].previousValue).toBe('1', 'after update previousValue');
+    expect(changes[1].firstChange).toBe(false, 'after update firstChange');
+  });
+
+  it('should not update when value is equal', () => {
+    spectator = createComponent({ props: { value: '1' } });
+
+    const { changes } = spectator.component;
+
+    expect(changes.length).toBe(1, 'size after compile');
+
+    spectator.setInput({ value: '1' });
+    expect(changes.length).toBe(1, 'not updated');
+  });
+});

--- a/projects/spectator/test/simple-changes/simple-changes.component.ts
+++ b/projects/spectator/test/simple-changes/simple-changes.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input, OnChanges, OnInit, SimpleChange, SimpleChanges } from '@angular/core';
+
+// tslint:disable:template-no-call-expression
+
+@Component({
+  selector: 'app-simple-changes',
+  template: ``
+})
+export class SimpleChangesComponent implements OnInit, OnChanges {
+  @Input() public value;
+
+  public hooks: string[] = [];
+  public changes: SimpleChange[] = [];
+
+  public ngOnInit(): void {
+    this.hooks.push('ngOnInit');
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    this.hooks.push('ngOnChanges');
+
+    if ('value' in changes) {
+      this.changes.push(changes.value);
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] (not need) Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When setting input bingins via `createComponentFactory(TestComponent)({ props: {} })` or  run `spectator.setInput(...)`, hook `ngOnChanges` is not called.

Issue Number: #348


## What is the new behavior?
The hook `ngOnChanges` fired on first install input's and update via `spectator.setInput()`, `spectator.setHostInput()`


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Now, internal `setProps` update value of instance only if values not equals. It is affected `setInput`, `setHostInput`.