### PR TITLE
Fix update values via setInput

### DIFF
--- a/projects/spectator/src/lib/internals/query.ts
+++ b/projects/spectator/src/lib/internals/query.ts
@@ -37,11 +37,10 @@ export function setProps(instance: any, keyOrKeyValues: any, value?: any, firstC
   const changes: SimpleChanges = {};
 
   const update = (key: string, newValue: any): void => {
-    if (instance[key] === newValue) {
-      return;
+    if (instance[key] !== newValue) {
+      changes[key] = new SimpleChange(instance[key], newValue, firstChange);
     }
 
-    changes[key] = new SimpleChange(instance[key], newValue, firstChange);
     instance[key] = newValue;
   };
 

--- a/projects/spectator/test/set-input/set-input.component.spec.ts
+++ b/projects/spectator/test/set-input/set-input.component.spec.ts
@@ -1,0 +1,57 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { CommonModule } from '@angular/common';
+
+import { SetInputComponent } from './set-input.component';
+
+describe('SetInputComponent', () => {
+  let spectator: Spectator<SetInputComponent>;
+
+  const createComponent = createComponentFactory({
+    component: SetInputComponent,
+    imports: [CommonModule]
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+  });
+
+  it('should be update input from object', () => {
+    spectator.setInput({ one: '1' });
+
+    expect(spectator.component.one).toBe('1');
+  });
+
+  it('should be update input from 2 arguments', () => {
+    spectator.setInput('one', '1');
+
+    expect(spectator.component.one).toBe('1');
+  });
+
+  it('should be update input via 2 arguments with undefined', () => {
+    spectator.setInput('one', undefined);
+
+    expect(spectator.component.one).toBeUndefined();
+  });
+
+  it('should be update input setter', () => {
+    spectator.setInput('two', '2');
+
+    expect(spectator.component.another).toBe('2');
+  });
+
+  it('should be update input setter with undefined', () => {
+    spectator.setInput('two', undefined);
+
+    expect(spectator.component.another).toBeUndefined();
+  });
+
+  it('should be update input setter to undefined after some value', () => {
+    spectator.setInput('two', 'two');
+
+    expect(spectator.component.another).toBe('two');
+
+    spectator.setInput('two', undefined);
+
+    expect(spectator.component.another).toBeUndefined();
+  });
+});

--- a/projects/spectator/test/set-input/set-input.component.ts
+++ b/projects/spectator/test/set-input/set-input.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+// tslint:disable:template-no-call-expression
+
+@Component({
+  selector: 'app-set-input',
+  template: ``
+})
+export class SetInputComponent {
+  public another;
+
+  @Input() public one;
+  @Input() public set two(value: any) {
+    this.another = value;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`setInput` not update instance value if equals previous and new value. It's not work with only setter `Input`

Issue Number: 367


## What is the new behavior?
`setInput` update instance values always.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```