### PR TITLE
feat: add VSCode snippets for jest

### DIFF
--- a/vscode-snippets/README.md
+++ b/vscode-snippets/README.md
@@ -9,4 +9,10 @@ spec-directive
 spec-service
 spec-http
 spec-routing
+spec-spec-comp
+spec-spec-host
+spec-spec-directive
+spec-spec-service
+spec-spec-http
+spec-spec-routing
 ```

--- a/vscode-snippets/snippets/snippets.json
+++ b/vscode-snippets/snippets/snippets.json
@@ -147,5 +147,154 @@
       "});"
     ],
     "description": "createRoutingFactory"
+  },
+  "createJestComponentFactory": {
+    "prefix": "spec-jest-comp",
+    "body": [
+      "import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Component } from './${2:path}.component';",
+      "",
+      "describe('${1:name}Component', () => {",
+      "  let spectator: Spectator<${1:name}Component>;",
+      "  const createComponent = createComponentFactory(${1:name}Component);",
+      "  ",
+      "  beforeEach(() => spectator = createComponent());",
+      "",
+      "  it('should ', () => {",
+      "    expect(spectator.query('button')).toHaveClass('success');",
+      "  });",
+      "});"
+    ],
+    "description": "createJestComponentFactory"
+  },
+  "createJestHostFactory": {
+    "prefix": "spec-jest-host",
+    "body": [
+      "import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Component } from './${2:path}.component';",
+      "",
+      "describe('${1:name}Component', () => {",
+      "  let spectator: SpectatorHost<${1:name}Component>;",
+      "  const createHost = createHostFactory(${1:name}Component);",
+      "",
+      "  it('should ', () => {",
+      "    spectator = createHost(`<zippy>Hello</zippy>`);",
+      "    expect(spectator.query('.zippy__title')).toHaveText('Hello');",
+      "  });",
+      "",
+      "});"
+    ],
+    "description": "createJestHostFactory"
+  },
+  "createJestDirectiveFactory": {
+    "prefix": "spec-jest-directive",
+    "body": [
+      "import { SpectatorDirective, createDirectiveFactory } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Directive } from './${2:path}.directive';",
+      "",
+      "describe('${1:name}Directive', () => {",
+      "  let spectator: SpectatorDirective<HighlightDirective>;",
+      "  const createDirective = createDirectiveFactory(HighlightDirective);",
+      "",
+      "",
+      "  beforeEach(() => {",
+      "    spectator = createDirective(`<div ${3:selector}></div>`);",
+      "  });",
+      "",
+      "  it('should ', () => {",
+      "     ",
+      "  });",
+      "});"
+    ],
+    "description": "createJestDirectiveFactory"
+  },
+  "createJestServiceFactory": {
+    "prefix": "spec-jest-service",
+    "body": [
+      "import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Service } from './${2:path}.service';",
+      "",
+      "describe('${1:name}Service', () => {",
+      "  let spectator: SpectatorService<${1:name}Service>;",
+      "  const createService = createServiceFactory({",
+      "    service: ${1:name}Service,",
+      "    mocks: []",
+      "  });",
+      "",
+      "  ",
+      "  beforeEach(() => spectator = createService());",
+      "",
+      "  it('should ', () => {",
+      "    ",
+      "  });",
+      "});"
+    ],
+    "description": "createJestServiceFactory"
+  },
+  "createJestPipeFactory": {
+    "prefix": "spec-pipe",
+    "body": [
+      "import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Pipe } from './${2:path}.pipe';",
+      "",
+      "describe('${1:name}Pipe', () => {",
+      "  let spectator: SpectatorPipe<${1:name}Pipe>;",
+      "  const createPipe = createPipeFactory({",
+      "    pipe: ${1:name}Pipe,",
+      "    mocks: []",
+      "  });",
+      "",
+      "",
+      "  it('should ', () => {",
+      "    spectator = createPipe(`{{ 'value' | ${1:name} }}`);",
+      "  });",
+      "});"
+    ],
+    "description": "createJestPipeFactory"
+  },
+  "createJestHttpFactory": {
+    "prefix": "spec-jest-http",
+    "body": [
+      "import { createHttpFactory, HttpMethod, SpectatorHttp } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Service } from './${2:path}.service';",
+      "",
+      "describe('${1:name}Service', () => {",
+      "  let spectator: SpectatorHttp<${1:name}Service>;",
+      "  const createHttp = createHttpFactory(${1:name}Service);",
+      "",
+      "  beforeEach(() => spectator = createHttp());",
+      "",
+      "  it('should test HttpClient.get', () => {",
+      "    spectator.dataService.get().subscribe();",
+      "    spectator.expectOne('todos', HTTPMethod.GET);",
+      "  });",
+      "});"
+    ],
+    "description": "createJestHttpFactory"
+  },
+  "createJestRoutingFactory": {
+    "prefix": "spec-jest-routing",
+    "body": [
+      "import { createRoutingFactory, SpectatorRouting } from '@ngneat/spectator/jest';",
+      "import { ${1:name}Component } from './${2:path}.component';",
+      "",
+      "describe('${1:name}Component', () => {",
+      "  let spectator: SpectatorRouting<${1:name}Component>; ",
+      "  const createComponent = createRoutingFactory({",
+      "    component: ${1:name}Component,",
+      "    data: {},",
+      "    params: {},",
+      "    queryParams: {}",
+      "  });",
+      "",
+      "  beforeEach(() => spectator = createComponent());",
+      "",
+      "  it('should ', () => {",
+      "      ",
+      "  });",
+      "",
+      "});"
+    ],
+    "description": "createJestRoutingFactory"
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
VSCode snippets are only compatible with Jasmine (import from '@ngneat/spectator')

Issue Number: #404 


## What is the new behavior?
New snippets like `spec-jest-comp` are added, which will import from ('@ngneat/spectator/jest'')

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have suggested snippets like `spec-XXX-jest` in #404 , but in this PR I use `spec-jest-XXX`, because that might be less annoying for current ('spec-XXX') users on auto completion.
