### PR TITLE
feat(schematics): use actual component name in test file

### DIFF
--- a/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
+++ b/projects/spectator/schematics/src/spectator/files/component-host/__name@dasherize__.component.spec.ts
@@ -7,19 +7,20 @@ describe('<%= classify(name)%>Component', () => {
 
   const createHost = createHostFactory(<%= classify(name)%>Component);
 
+  beforeEach(() => {
+    spectator = createHost(`<app-<%= dasherize(name)%> title="Zippy title">Zippy content</app-<%= dasherize(name)%>>`);
+  });
+
   it('should create', () => {
-    spectator = createHost(`<zippy title="Zippy title"></zippy>`);
     expect(spectator.component).toBeTruthy();
   });
 
   it('should...', () => {
-    spectator = createHost(`<zippy title="Zippy title">Zippy content</zippy>`);
     spectator.click('.zippy__title');
     expect(spectator.query('.arrow')).toHaveText('Close');
   });
 
   it('should...', () => {
-    spectator = createHost(`<zippy title="Zippy title"></zippy>`);
     spectator.click('.zippy__title');
     expect(spectator.query('.zippy__content')).toExist();
     spectator.click('.zippy__title');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current test file generated for a component when using the `--with-host` flag uses a placeholder `zippy` selector rather than the actual selector for the new component (e.g. `createHost('<zippy title="Zippy title"></zippy>')` in the test file).

Issue Number: N/A


## What is the new behavior?
This updates the schematic to instead use the actual selector for the component instead, saving the step of having to update the selector used. So, `createHost('<zippy title="Zippy title"></zippy>')` becomes `createHost('<app-<%= dasherize(name)%> title="Zippy title">Zippy content</app-<%= dasherize(name)%>>')`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I didn't think this required a change in the docs but happy to document if you feel it would be helpful.