### PR TITLE
fix: adding a root option to trigger event handler method

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@angular/compiler": "^11.2.4",
     "@angular/compiler-cli": "^11.2.4",
     "@angular/core": "^11.2.4",
+    "@angular/cdk": "^11.2.4",
     "@angular/forms": "^11.2.4",
     "@angular/language-service": "^11.2.4",
     "@angular/platform-browser": "^11.2.4",

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -29,9 +29,10 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": ">= 10.1.0",
-    "@angular/core": ">= 10.1.0",
-    "@angular/router": ">= 10.1.0",
+    "@angular/common": ">= 11.1.0",
+    "@angular/core": ">= 11.1.0",
+    "@angular/router": ">= 11.1.0",
+    "@angular/cdk": ">= 11.1.0",
     "typescript": ">= 2.8.0"
   },
   "bin": {

--- a/projects/spectator/test/overlay-custom-event/overlay-container.component.spec.ts
+++ b/projects/spectator/test/overlay-custom-event/overlay-container.component.spec.ts
@@ -1,0 +1,36 @@
+import { Overlay } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { Component } from '@angular/core';
+import { Spectator, createComponentFactory, SpectatorHost } from '@ngneat/spectator';
+
+import { byText } from '@ngneat/spectator';
+import { OverlayContainerComponent } from './overlay-container.component';
+import { OverlayContainerModule } from './overlay-container.module';
+import { OverlayContentComponent } from './overlay-content.component';
+
+describe('Overlay container custom event', () => {
+  let spectator: Spectator<object>;
+
+  const createComponent = createComponentFactory({
+    component: Component({
+      selector: 'test-host',
+      template: '<div></div>'
+    })(class {}),
+    imports: [OverlayContainerModule]
+  });
+
+  it('should trigger custom event on a component inside an overlay', () => {
+    spectator = createComponent();
+    const overlayRef = spectator.inject(Overlay).create();
+    const componentPortal = new ComponentPortal<unknown>(OverlayContainerComponent);
+    overlayRef.attach(componentPortal);
+
+    spectator.triggerEventHandler(OverlayContentComponent, 'customEvent', 'hello');
+    expect(spectator.query(byText('hello'), { root: true })).not.toExist();
+
+    spectator.triggerEventHandler(OverlayContentComponent, 'customEvent', 'hello', { root: true });
+    expect(spectator.query(byText('hello'), { root: true })).toExist();
+
+    overlayRef.dispose();
+  });
+});

--- a/projects/spectator/test/overlay-custom-event/overlay-container.component.ts
+++ b/projects/spectator/test/overlay-custom-event/overlay-container.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-overlay-container',
+  template: `
+    <app-overlay-content (customEvent)="onCustomEvent($event)"></app-overlay-content>
+    <p>{{ eventValue }}</p>
+  `
+})
+export class OverlayContainerComponent {
+  public eventValue = '';
+
+  public onCustomEvent(eventValue: string): void {
+    this.eventValue = eventValue;
+  }
+}

--- a/projects/spectator/test/overlay-custom-event/overlay-container.module.ts
+++ b/projects/spectator/test/overlay-custom-event/overlay-container.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverlayModule } from '@angular/cdk/overlay';
+
+import { OverlayContainerComponent } from './overlay-container.component';
+import { OverlayContentComponent } from './overlay-content.component';
+
+@NgModule({
+  imports: [CommonModule, OverlayModule],
+  declarations: [OverlayContainerComponent, OverlayContentComponent],
+  exports: [OverlayContainerComponent]
+})
+export class OverlayContainerModule {}

--- a/projects/spectator/test/overlay-custom-event/overlay-content.component.ts
+++ b/projects/spectator/test/overlay-custom-event/overlay-content.component.ts
@@ -1,0 +1,11 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'app-overlay-content',
+  template: `
+    <p>Overlay Content</p>
+  `
+})
+export class OverlayContentComponent {
+  @Output() customEvent = new EventEmitter<string>();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,15 @@
   dependencies:
     tslib "^2.0.0"
 
+"@angular/cdk@^11.2.4":
+  version "11.2.4"
+  resolved "https://registry.npmjs.org/@angular/cdk/-/cdk-11.2.4.tgz#7b2afc2609625383903ae458bf67640aa2179b9c"
+  integrity sha512-BcMHRaKZxkpK+dPwmjqktAzWUnywbyHyrORGlF4OMtbE88IvbI8tQ+0xANfBm0cPaAm+na5AlGKyH2ptzedyRQ==
+  dependencies:
+    tslib "^2.0.0"
+  optionalDependencies:
+    parse5 "^5.0.0"
+
 "@angular/cli@^11.2.3":
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-11.2.3.tgz#bd27a01994a907b606563a69cb28b9c2e474c171"
@@ -8808,9 +8817,9 @@ parse5-sax-parser@^6.0.1:
   dependencies:
     parse5 "^6.0.1"
 
-parse5@5.1.1:
+parse5@5.1.1, parse5@^5.0.0:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 parse5@^6.0.1:


### PR DESCRIPTION
fix: adding a root option to trigger event handler method
- TriggerEventHandler method currently doesn't support a search from root. Some angular components can create overlay elements which are part of the root and so, are not descendants of the current test dom element.

This change adds the support for finding the trigger component from the root. For this we are traversing up the DebugElement tree using the parent property. It is still a bounded search since the tree traversal will end at the root. Happy to explore other better approaches.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Adding a new option to `triggerEventHandler` method that would allow searching for element from root, similar to `query` method.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/spectator/issues/414


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
