### PR TITLE
feature(createHostFactory): PR for issue #443

### DIFF
--- a/projects/spectator/src/lib/spectator-host/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-host/create-factory.ts
@@ -58,11 +58,20 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
   beforeEach(
     waitForAsync(() => {
       addMatchers(customMatchers);
-      TestBed.configureTestingModule(moduleMetadata);
+      TestBed.configureTestingModule(moduleMetadata).overrideModule(BrowserDynamicTestingModule, {
+      set: {
+        entryComponents: moduleMetadata.entryComponents
+      }
+    });
 
       overrideModules(options);
 
       overrideComponentIfProviderOverridesSpecified(options);
+      if (options.template) {
+        TestBed.overrideComponent(options.host, {
+           set: { template: options.template }
+        });
+      }
     })
   );
 
@@ -76,13 +85,11 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
       });
     }
 
-    TestBed.overrideModule(BrowserDynamicTestingModule, {
-      set: {
-        entryComponents: moduleMetadata.entryComponents
-      }
-    }).overrideComponent(options.host, {
-      set: { template: template || options.template }
-    });
+    if (template) {
+      TestBed.overrideComponent(options.host, {
+        set: { template: template }
+      });
+    }
 
     const spectator = createSpectatorHost(options, props, hostProps);
 


### PR DESCRIPTION
Refactoring of createHostFactory to defer TestBed instantiation.  This also allows for use of Angular's spec injection functionality.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: 443
[Support spec injection when testing with a host component](https://github.com/ngneat/spectator/issues/443)


## What is the new behavior?
`template` option can be passed to `createHostFactory ` and then omitted from `spectatorHostFactory`.  This allows for instantiation of TestBed prior to the call to `spectatorHostFactory`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
`zippy.component.spec.ts` already has tests that cover the code paths of this feature, and all existing tests are passing.  

I did not modify any docs because this feature simply allows `spectatorHostFactory` to defer `TestBed` instantiation in the same way that `spectatorFactory` already does.
If you would like me to make that explicit, I am happy to modify this PR.

I believe I covered all the bases, but as this is my first PR for this project, please let me know if anything is missing or needs corrected for this submission.