### PR TITLE
docs(testing-with-http): add missing import in example

### DIFF
--- a/docs/docs/testing-with-http.md
+++ b/docs/docs/testing-with-http.md
@@ -29,7 +29,7 @@ export class TodosDataService {
 
 The test for the above service should look like:
 ```ts
-import { createHttpFactory, HttpMethod } from '@ngneat/spectator';
+import { createHttpFactory, HttpMethod, SpectatorHttp } from '@ngneat/spectator';
 import { TodosDataService } from './todos-data.service';
 
 describe('HttpClient testing', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The example missed the required `SpectatorHttp` import.


## What is the new behavior?

The documentation will show all required imports in the example


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
