### PR TITLE
docs(oninit-lifecycle-tests): mocked services in OnInit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Spectator helps you get rid of all the boilerplate grunt work, leaving you with 
 - [Testing Pipes](#testing-pipes)
   - [Using Custom Host Component](#using-custom-host-component)
 - [Mocking Providers](#mocking-providers)
+  - [Mocking OnInit Dependencies](#mocking-oninit-dependencies)
 - [Jest Support](#jest-support)
 - [Testing with HTTP](#testing-with-http)
 - [Global Injections](#global-injections)
@@ -895,6 +896,28 @@ const createService = createServiceFactory({
     })
   ],
 });
+```
+
+### Mocking OnInit dependencies
+
+If a component relies on a service being mocked in the [OnInit](https://angular.io/api/core/OnInit) lifecycle method, change-detection needs to be disabled until after the services have been injected.
+
+To configure this, change the `createComponent` method to have the `detectChanges` option set to false and then manually call `detectChanges` on the spectator after setting up the injected services.
+
+```ts
+const createComponent = createComponentFactory({
+  component: WeatherDashboardComponent
+});
+
+it('should call the weather api on init', () => {
+  const spectator = createComponent({
+    detectChanges: false
+  });
+  const weatherService = spectator.inject(WeatherDataApi);
+  weatherService.getWeatherData.andReturn(of(mockWeatherData));
+  spectator.detectChanges();
+  expect(weatherService.getWeatherData).toHaveBeenCalled();
+})
 ```
 
 ## Jest Support


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I ran into the same issue that another user of specator encountered where service dependencies used in OnInit are not initialized because detectChanges runs before the dependencies are injected.

Issue Number: #308

## What is the new behavior?

Simply documenting how to properly write the test so that less users struggle with this.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

## Other information
