### PR TITLE
fix(DomSpectator): setInput not trigger angular hooks

### DIFF
--- a/projects/spectator/jest/test/form-input/form-input.component.spec.ts
+++ b/projects/spectator/jest/test/form-input/form-input.component.spec.ts
@@ -4,53 +4,51 @@ import { createHostFactory, SpectatorHost, Spectator, createComponentFactory } f
 import { FormInputComponent } from '../../../test/form-input/form-input.component';
 
 describe('FormInputComponent', () => {
-  let host: SpectatorHost<FormInputComponent>;
-  const createHost = createHostFactory({
-    component: FormInputComponent,
-    imports: [ReactiveFormsModule]
-  });
   const group = new FormGroup({ name: new FormControl('') });
 
-  it('should be defined', () => {
-    host = createHost(`<app-form-input [enableSubnet]="true"></app-form-input>`, {
-      detectChanges: true,
-      props: {
-        subnetControl: group
-      }
+  describe('via host template', () => {
+    let host: SpectatorHost<FormInputComponent>;
+    const createHost = createHostFactory({
+      component: FormInputComponent,
+      imports: [ReactiveFormsModule]
     });
 
-    expect(host.component).toBeDefined();
-    expect(host.query('p')).not.toBeNull();
-    host.setInput('enableSubnet', false);
-    expect(host.query('p')).toBeNull();
-  });
-});
+    it('should be defined', () => {
+      host = createHost(`<app-form-input [enableSubnet]="enableSubnet" [subnetControl]="subnetControl"></app-form-input>`, {
+        detectChanges: true,
+        hostProps: {
+          enableSubnet: true,
+          subnetControl: group
+        }
+      });
 
-describe('FormInputComponent', () => {
-  let spectator: Spectator<FormInputComponent>;
-  const group = new FormGroup({ name: new FormControl('') });
-
-  const inputs = {
-    subnetControl: group,
-    enableSubnet: true
-  };
-
-  const createComponent = createComponentFactory({
-    component: FormInputComponent,
-    imports: [ReactiveFormsModule]
+      expect(host.component).toBeDefined();
+      expect(host.query('p')).not.toBeNull();
+      host.setHostInput({ enableSubnet: false });
+      expect(host.query('p')).toBeNull();
+    });
   });
 
-  beforeEach(
-    () =>
-      (spectator = createComponent({
-        props: inputs
-      }))
-  );
+  describe('without host template', () => {
+    let spectator: Spectator<FormInputComponent>;
 
-  it('should work', () => {
-    expect(spectator.component).toBeDefined();
-    expect(spectator.query('p')).not.toBeNull();
-    spectator.setInput('enableSubnet', false);
-    expect(spectator.query('p')).toBeNull();
+    const createComponent = createComponentFactory({
+      component: FormInputComponent,
+      imports: [ReactiveFormsModule]
+    });
+
+    it('should be defined', () => {
+      spectator = createComponent({
+        props: {
+          subnetControl: group,
+          enableSubnet: true
+        }
+      });
+
+      expect(spectator.component).toBeDefined();
+      expect(spectator.query('p')).not.toBeNull();
+      spectator.setInput('enableSubnet', false);
+      expect(spectator.query('p')).toBeNull();
+    });
   });
 });

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, DebugElement, ElementRef, Type, EventEmitter } from '@angular/core';
+import { DebugElement, ElementRef, Type, EventEmitter } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ComponentFixture, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -7,7 +7,7 @@ import { Token } from '../token';
 import { DOMSelector } from '../dom-selectors';
 import { isString, QueryOptions, QueryType, SpectatorElement, EventEmitterType, KeysMatching, KeyboardEventOptions } from '../types';
 import { SpyObject } from '../mock';
-import { getChildren, setProps } from '../internals/query';
+import { getChildren, setProps, setMarkForCheck } from '../internals/query';
 import { patchElementFocus } from '../internals/element-focus';
 import { createMouseEvent } from '../event-creators';
 import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent, dispatchTouchEvent } from '../dispatch-events';
@@ -97,7 +97,8 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   public setInput<K extends keyof I>(input: K, inputValue: I[K]): void;
   public setInput(input: any, value?: any): void {
     setProps(this.instance, input, value, false);
-    this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
+    setMarkForCheck(this.debugElement);
+    this.detectChanges();
   }
 
   public output<T, K extends keyof I = keyof I>(output: K): Observable<T> {

--- a/projects/spectator/src/lib/internals/query.ts
+++ b/projects/spectator/src/lib/internals/query.ts
@@ -1,4 +1,4 @@
-import { DebugElement, SimpleChange, SimpleChanges } from '@angular/core';
+import { DebugElement, SimpleChange, SimpleChanges, ChangeDetectorRef } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 import { DOMSelector } from '../dom-selectors';
@@ -59,4 +59,8 @@ export function setProps(instance: any, keyOrKeyValues: any, value?: any, firstC
   }
 
   return instance;
+}
+
+export function setMarkForCheck(debugElement: DebugElement): void {
+  debugElement.injector.get(ChangeDetectorRef).markForCheck();
 }

--- a/projects/spectator/test/form-input/form-input.component.spec.ts
+++ b/projects/spectator/test/form-input/form-input.component.spec.ts
@@ -4,50 +4,51 @@ import { createHostFactory, SpectatorHost, Spectator, createComponentFactory } f
 import { FormInputComponent } from './form-input.component';
 
 describe('FormInputComponent', () => {
-  let host: SpectatorHost<FormInputComponent>;
-  const createHost = createHostFactory({
-    component: FormInputComponent,
-    imports: [ReactiveFormsModule]
-  });
   const group = new FormGroup({ name: new FormControl('') });
 
-  it('should be defined', () => {
-    host = createHost(`<app-form-input [enableSubnet]="true"></app-form-input>`, {
-      detectChanges: true,
-      props: {
-        subnetControl: group
-      }
+  describe('via host template', () => {
+    let host: SpectatorHost<FormInputComponent>;
+    const createHost = createHostFactory({
+      component: FormInputComponent,
+      imports: [ReactiveFormsModule]
     });
-    expect(host.component).toBeDefined();
-    expect(host.query('p')).not.toBeNull();
-    host.setInput('enableSubnet', false);
-    expect(host.query('p')).toBeNull();
+
+    it('should be defined', () => {
+      host = createHost(`<app-form-input [enableSubnet]="enableSubnet" [subnetControl]="subnetControl"></app-form-input>`, {
+        detectChanges: true,
+        hostProps: {
+          enableSubnet: true,
+          subnetControl: group
+        }
+      });
+
+      expect(host.component).toBeDefined();
+      expect(host.query('p')).not.toBeNull();
+      host.setHostInput({ enableSubnet: false });
+      expect(host.query('p')).toBeNull();
+    });
   });
-});
 
-describe('FormInputComponent', () => {
-  let spectator: Spectator<FormInputComponent>;
-  const group = new FormGroup({ name: new FormControl('') });
+  describe('without host template', () => {
+    let spectator: Spectator<FormInputComponent>;
 
-  const createComponent = createComponentFactory<FormInputComponent>({
-    component: FormInputComponent,
-    imports: [ReactiveFormsModule]
-  });
+    const createComponent = createComponentFactory({
+      component: FormInputComponent,
+      imports: [ReactiveFormsModule]
+    });
 
-  beforeEach(
-    () =>
-      (spectator = createComponent({
+    it('should be defined', () => {
+      spectator = createComponent({
         props: {
           subnetControl: group,
           enableSubnet: true
         }
-      }))
-  );
+      });
 
-  it('should work', () => {
-    expect(spectator.component).toBeDefined();
-    expect(spectator.query('p')).not.toBeNull();
-    spectator.setInput('enableSubnet', false);
-    expect(spectator.query('p')).toBeNull();
+      expect(spectator.component).toBeDefined();
+      expect(spectator.query('p')).not.toBeNull();
+      spectator.setInput('enableSubnet', false);
+      expect(spectator.query('p')).toBeNull();
+    });
   });
 });

--- a/projects/spectator/test/set-input/set-input.component.spec.ts
+++ b/projects/spectator/test/set-input/set-input.component.spec.ts
@@ -6,52 +6,83 @@ import { SetInputComponent } from './set-input.component';
 describe('SetInputComponent', () => {
   let spectator: Spectator<SetInputComponent>;
 
-  const createComponent = createComponentFactory({
-    component: SetInputComponent,
-    imports: [CommonModule]
+  describe('with default enabled detectChanges', () => {
+    const createComponent = createComponentFactory({
+      component: SetInputComponent,
+      imports: [CommonModule]
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should be set value from OnInit angular hook', () => {
+      expect(spectator.component.fromInit).toBe('initValue');
+    });
+
+    it('should be update input from object', () => {
+      spectator.setInput({ one: '1' });
+
+      expect(spectator.component.one).toBe('1');
+    });
+
+    it('should be update input from 2 arguments', () => {
+      spectator.setInput('one', '1');
+
+      expect(spectator.component.one).toBe('1');
+    });
+
+    it('should be update input via 2 arguments with undefined', () => {
+      spectator.setInput('one', undefined);
+
+      expect(spectator.component.one).toBeUndefined();
+    });
+
+    it('should be update input setter', () => {
+      spectator.setInput('two', '2');
+
+      expect(spectator.component.another).toBe('2');
+    });
+
+    it('should be update input setter with undefined', () => {
+      spectator.setInput('two', undefined);
+
+      expect(spectator.component.another).toBeUndefined();
+    });
+
+    it('should be update input setter to undefined after some value', () => {
+      spectator.setInput('two', 'two');
+
+      expect(spectator.component.another).toBe('two');
+
+      spectator.setInput('two', undefined);
+
+      expect(spectator.component.another).toBeUndefined();
+    });
   });
 
-  beforeEach(() => {
-    spectator = createComponent();
-  });
+  describe('without detectChanges after compile component', () => {
+    const createComponent = createComponentFactory({
+      component: SetInputComponent,
+      imports: [CommonModule],
+      detectChanges: false
+    });
 
-  it('should be update input from object', () => {
-    spectator.setInput({ one: '1' });
+    beforeEach(() => {
+      spectator = createComponent();
+    });
 
-    expect(spectator.component.one).toBe('1');
-  });
+    it('should be set value from OnInit angular hook with manual detectChanges', () => {
+      spectator.detectChanges();
 
-  it('should be update input from 2 arguments', () => {
-    spectator.setInput('one', '1');
+      expect(spectator.component.fromInit).toBe('initValue');
+    });
 
-    expect(spectator.component.one).toBe('1');
-  });
+    it('should be set value from OnInit angular hook when call setInput', () => {
+      spectator.setInput({ one: '1' });
 
-  it('should be update input via 2 arguments with undefined', () => {
-    spectator.setInput('one', undefined);
-
-    expect(spectator.component.one).toBeUndefined();
-  });
-
-  it('should be update input setter', () => {
-    spectator.setInput('two', '2');
-
-    expect(spectator.component.another).toBe('2');
-  });
-
-  it('should be update input setter with undefined', () => {
-    spectator.setInput('two', undefined);
-
-    expect(spectator.component.another).toBeUndefined();
-  });
-
-  it('should be update input setter to undefined after some value', () => {
-    spectator.setInput('two', 'two');
-
-    expect(spectator.component.another).toBe('two');
-
-    spectator.setInput('two', undefined);
-
-    expect(spectator.component.another).toBeUndefined();
+      expect(spectator.component.one).toBe('1');
+      expect(spectator.component.fromInit).toBe('initValue');
+    });
   });
 });

--- a/projects/spectator/test/set-input/set-input.component.ts
+++ b/projects/spectator/test/set-input/set-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 /* eslint-disable @angular-eslint/template/no-call-expression */
 
@@ -6,11 +6,16 @@ import { Component, Input } from '@angular/core';
   selector: 'app-set-input',
   template: ``,
 })
-export class SetInputComponent {
+export class SetInputComponent implements OnInit {
   public another;
+  public fromInit;
 
   @Input() public one;
   @Input() public set two(value: any) {
     this.another = value;
+  }
+
+  ngOnInit(): void {
+    this.fromInit = 'initValue';
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `setInput` not call angular hooks on testing component.

Issue Number: #461 

## What is the new behavior?
The `setInput` call angular hooks on testing component now.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

The `setInput` call root `detectChanges` from `fixture` now.
