### PR TITLE
Bug/373 jest focus

### DIFF
--- a/projects/spectator/jest/test/focus/test-focus.component.spec.ts
+++ b/projects/spectator/jest/test/focus/test-focus.component.spec.ts
@@ -30,4 +30,15 @@ describe('SpectatorHost.focus() in jest', () => {
     expect(host.component.blurCount('button2')).toBe(0);
   });
 
+
+  it('calling focus() multiple times does not cause multiple patches', () => {
+    host.focus('#button1');
+    host.focus();
+    host.focus('#button1');
+
+    expect(host.component.focusCount('app-test-focus')).toBe(1);
+    expect(host.component.focusCount('button1')).toBe(2);
+    expect(host.component.blurCount('button1')).toBe(1);
+  });
+  
 });

--- a/projects/spectator/jest/test/focus/test-focus.component.spec.ts
+++ b/projects/spectator/jest/test/focus/test-focus.component.spec.ts
@@ -1,0 +1,33 @@
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator/jest';
+
+import { TestFocusComponent } from '../../../test/focus/test-focus.component';
+
+describe('SpectatorHost.focus() in jest', () => {
+
+  const createHost = createHostFactory(TestFocusComponent);
+  let host: SpectatorHost<TestFocusComponent>;
+
+  beforeEach(() => {
+    host = createHost('<app-test-focus></app-test-focus>');
+  })
+
+  it('sets document.activeElement', () => {
+    host.focus('#button1');
+
+    expect(host.query('#button1')).toBeFocused();
+  });
+
+  it('causes blur events', () => {
+    host.focus();
+    host.focus('#button1');
+    host.focus('#button2');
+
+    expect(host.component.focusCount('app-test-focus')).toBe(1);
+    expect(host.component.blurCount('app-test-focus')).toBe(1);
+    expect(host.component.focusCount('button1')).toBe(1);
+    expect(host.component.blurCount('button1')).toBe(1);
+    expect(host.component.focusCount('button2')).toBe(1);
+    expect(host.component.blurCount('button2')).toBe(0);
+  });
+
+});

--- a/projects/spectator/src/lib/internals/element-focus.ts
+++ b/projects/spectator/src/lib/internals/element-focus.ts
@@ -4,8 +4,47 @@ import { isRunningInJsDom } from '../utils';
 /** Property name added to HTML Elements to ensure we don't double-patch focus methods on an element. */
 const IS_FOCUS_PATCHED_PROP = '_patched_focus';
 
+/** Ensures that a single set of matching focus and blur events occur when HTMLElement.focus() is called. */
+class FocusEventWatcher implements EventListenerObject {
+
+  private readonly _active: Element | null;
+  private _blurred = false;
+  private _focused = false;
+
+  constructor(private readonly _e: HTMLElement) {
+    this._active = _e.ownerDocument.activeElement;
+    this._e.addEventListener('focus', this);
+    this._active?.addEventListener('blur', this);
+  }
+  public handleEvent(evt: Event): void {
+    if (evt.type === 'focus') {
+      this._focused = true;
+    }
+    else if (evt.type === 'blur') {
+      this._blurred = true;
+    }
+  }
+
+  /**
+   * If focus and blur events haven't occurred, fire fake ones.
+   */
+  public ensureFocusEvents() {
+    this._e.removeEventListener('focus', this);
+    this._active?.removeEventListener('blur', this);
+
+    // Ensure activeElement is blurred
+    if (this._active && !this._blurred && this._active === this._e.ownerDocument.activeElement) {
+      dispatchFakeEvent(this._active, 'blur');
+    }
+
+    if (!this._focused) {
+      dispatchFakeEvent(this._e, 'focus'); // Needed to cause focus event
+    }
+  }
+}
+
 /**
- * Patches an elements focus and blur methods to emit events consistently and predictably.
+ * Patches an element's focus and blur methods to emit events consistently and predictably in tests.
  * This is necessary, because some browsers, like IE11, will call the focus handlers asynchronously,
  * while others won't fire them at all if the browser window is not focused.
  *
@@ -17,15 +56,12 @@ export function patchElementFocus(element: HTMLElement): void {
   if (!isRunningInJsDom() && (element[IS_FOCUS_PATCHED_PROP] === undefined)) {
     const baseFocus = element.focus.bind(element);
     element.focus = (options) => {
-      // Blur current active
-      const active = element.ownerDocument.activeElement;
-      if (active) {
-        dispatchFakeEvent(active, 'blur');
-      }
+      const w = new FocusEventWatcher(element);
 
-      // Focus
-      baseFocus(options); // Needed to set document.activeElement
-      dispatchFakeEvent(element, 'focus'); // Needed to cause focus event
+      // Sets document.activeElement. May or may not send focus + blur events
+      baseFocus(options);
+
+      w.ensureFocusEvents();
     }
     element.blur = () => dispatchFakeEvent(element, 'blur');
     element[IS_FOCUS_PATCHED_PROP] = true;

--- a/projects/spectator/src/lib/internals/element-focus.ts
+++ b/projects/spectator/src/lib/internals/element-focus.ts
@@ -1,4 +1,8 @@
 import { dispatchFakeEvent } from '../dispatch-events';
+import { isRunningInJsDom } from '../utils';
+
+/** Property name added to HTML Elements to ensure we don't double-patch focus methods on an element. */
+const IS_FOCUS_PATCHED_PROP = '_patched_focus';
 
 /**
  * Patches an elements focus and blur methods to emit events consistently and predictably.
@@ -8,6 +12,22 @@ import { dispatchFakeEvent } from '../dispatch-events';
  * patchElementFocus(triggerEl);
  */
 export function patchElementFocus(element: HTMLElement): void {
-  element.focus = () => dispatchFakeEvent(element, 'focus');
-  element.blur = () => dispatchFakeEvent(element, 'blur');
+
+  // https://github.com/ngneat/spectator/issues/373 - Don't patch when using JSDOM, eg in Jest
+  if (!isRunningInJsDom() && (element[IS_FOCUS_PATCHED_PROP] === undefined)) {
+    const baseFocus = element.focus.bind(element);
+    element.focus = (options) => {
+      // Blur current active
+      const active = element.ownerDocument.activeElement;
+      if (active) {
+        dispatchFakeEvent(active, 'blur');
+      }
+
+      // Focus
+      baseFocus(options); // Needed to set document.activeElement
+      dispatchFakeEvent(element, 'focus'); // Needed to cause focus event
+    }
+    element.blur = () => dispatchFakeEvent(element, 'blur');
+    element[IS_FOCUS_PATCHED_PROP] = true;
+  }
 }

--- a/projects/spectator/src/lib/internals/element-focus.ts
+++ b/projects/spectator/src/lib/internals/element-focus.ts
@@ -1,26 +1,30 @@
 import { dispatchFakeEvent } from '../dispatch-events';
 import { isRunningInJsDom } from '../utils';
 
-/** Property name added to HTML Elements to ensure we don't double-patch focus methods on an element. */
-const IS_FOCUS_PATCHED_PROP = '_patched_focus';
+/** Property added to HTML Elements to ensure we don't double-patch focus methods on an element. */
+const IS_FOCUS_PATCHED_PROP = Symbol('isFocusPatched');
 
 /** Ensures that a single set of matching focus and blur events occur when HTMLElement.focus() is called. */
 class FocusEventWatcher implements EventListenerObject {
 
-  private readonly _active: Element | null;
+  private readonly priorActiveElement: Element | null;
+
+  /** Set to true when browser sends a blur event for priorActiveElement */
   private _blurred = false;
+  /** Set to true when browser sends a focus event for element */
   private _focused = false;
 
-  constructor(private readonly _e: HTMLElement) {
-    this._active = _e.ownerDocument.activeElement;
-    this._e.addEventListener('focus', this);
-    this._active?.addEventListener('blur', this);
+  constructor(private readonly element: HTMLElement) {
+    this.element.addEventListener('focus', this);
+    this.priorActiveElement = element.ownerDocument.activeElement;
+    this.priorActiveElement?.addEventListener('blur', this);
   }
-  public handleEvent(evt: Event): void {
-    if (evt.type === 'focus') {
+
+  public handleEvent({ type }: Event): void {
+    if (type === 'focus') {
       this._focused = true;
     }
-    else if (evt.type === 'blur') {
+    else if (type === 'blur') {
       this._blurred = true;
     }
   }
@@ -29,16 +33,16 @@ class FocusEventWatcher implements EventListenerObject {
    * If focus and blur events haven't occurred, fire fake ones.
    */
   public ensureFocusEvents() {
-    this._e.removeEventListener('focus', this);
-    this._active?.removeEventListener('blur', this);
+    this.element.removeEventListener('focus', this);
+    this.priorActiveElement?.removeEventListener('blur', this);
 
-    // Ensure activeElement is blurred
-    if (this._active && !this._blurred && this._active === this._e.ownerDocument.activeElement) {
-      dispatchFakeEvent(this._active, 'blur');
+    // Ensure priorActiveElement is blurred
+    if (!this._blurred && this.priorActiveElement) {
+      dispatchFakeEvent(this.priorActiveElement, 'blur');
     }
 
     if (!this._focused) {
-      dispatchFakeEvent(this._e, 'focus'); // Needed to cause focus event
+      dispatchFakeEvent(this.element, 'focus'); // Needed to cause focus event
     }
   }
 }
@@ -54,14 +58,14 @@ export function patchElementFocus(element: HTMLElement): void {
 
   // https://github.com/ngneat/spectator/issues/373 - Don't patch when using JSDOM, eg in Jest
   if (!isRunningInJsDom() && (element[IS_FOCUS_PATCHED_PROP] === undefined)) {
-    const baseFocus = element.focus.bind(element);
+    const originalFocus = element.focus.bind(element);
     element.focus = (options) => {
-      const w = new FocusEventWatcher(element);
+      const focusEventWatcher = new FocusEventWatcher(element);
 
       // Sets document.activeElement. May or may not send focus + blur events
-      baseFocus(options);
+      originalFocus(options);
 
-      w.ensureFocusEvents();
+      focusEventWatcher.ensureFocusEvents();
     }
     element.blur = () => dispatchFakeEvent(element, 'blur');
     element[IS_FOCUS_PATCHED_PROP] = true;

--- a/projects/spectator/test/focus/test-focus.component.spec.ts
+++ b/projects/spectator/test/focus/test-focus.component.spec.ts
@@ -1,0 +1,32 @@
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
+import { TestFocusComponent } from './test-focus.component';
+
+describe('SpectatorHost.focus() ', () => {
+
+  const createHost = createHostFactory(TestFocusComponent);
+  let host: SpectatorHost<TestFocusComponent>;
+
+  beforeEach(() => {
+    host = createHost('<app-test-focus></app-test-focus>');
+  })
+
+  it('sets document.activeElement', () => {
+    host.focus('#button1');
+
+    expect(host.query('#button1')).toBeFocused();
+  });
+
+  it('causes blur events', () => {
+    host.focus();
+    host.focus('#button1');
+    host.focus('#button2');
+
+    expect(host.component.focusCount('app-test-focus')).toBe(1);
+    expect(host.component.blurCount('app-test-focus')).toBe(1);
+    expect(host.component.focusCount('button1')).toBe(1);
+    expect(host.component.blurCount('button1')).toBe(1);
+    expect(host.component.focusCount('button2')).toBe(1);
+    expect(host.component.blurCount('button2')).toBe(0);
+  });
+
+});

--- a/projects/spectator/test/focus/test-focus.component.spec.ts
+++ b/projects/spectator/test/focus/test-focus.component.spec.ts
@@ -29,4 +29,14 @@ describe('SpectatorHost.focus() ', () => {
     expect(host.component.blurCount('button2')).toBe(0);
   });
 
+  it('calling focus() multiple times does not cause multiple patches', () => {
+    host.focus('#button1');
+    host.focus();
+    host.focus('#button1');
+
+    expect(host.component.focusCount('app-test-focus')).toBe(1);
+    expect(host.component.focusCount('button1')).toBe(2);
+    expect(host.component.blurCount('button1')).toBe(1);
+  });
+
 });

--- a/projects/spectator/test/focus/test-focus.component.ts
+++ b/projects/spectator/test/focus/test-focus.component.ts
@@ -1,0 +1,35 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test-focus',
+  template: `<button id="button1" (focus)="countFocus('button1')" (blur)="countBlur('button1')">Button1</button>
+             <button id="button2" (focus)="countFocus('button2')" (blur)="countBlur('button2')">Button2</button>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.tabindex]': '0',
+    '(focus)': 'countFocus("app-test-focus")',
+    '(blur)': 'countBlur("app-test-focus")'
+  }
+})
+export class TestFocusComponent {
+
+  private readonly focusCounts = new Map<string, number>();
+  private readonly blurCounts = new Map<string, number>();
+
+  public countFocus(id: string) {
+    this.focusCounts.set(id, this.focusCount(id) + 1);
+  }
+
+  public countBlur(id: string) {
+    this.blurCounts.set(id, this.blurCount(id) + 1);
+  }
+
+  public focusCount(id: string): number {
+    return this.focusCounts.get(id) ?? 0;
+  }
+
+  public blurCount(id: string): number {
+    return this.blurCounts.get(id) ?? 0;
+  }
+
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #373

## What is the new behavior?
1. In Jest (more specifically jsdom), the patch for `HTMLElement.focus()` and `HTMLElement.blur()` is not applied.
2. In browsers, when the  `HTMLElement.focus()` is patched the patched implementation is more robust. It calls the browser's `HTMLElement.focus()` method first, and if the focus and/or blur events are not detected when `focus()` is called, it sends the fake events. This ensures that `document.activeElement` is set (so the `toBeFocused()` matcher works, and app behavior that depends on `document.activeElement` works), and it ensures that a single focus event, and 0-1 blur events, are emitted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

There is no API change, but there is a change in behavior, that could conceivably break tests that depend on the old behavior (most likely to work around it). However this should be unlikely.

`focus()` and `blur()` were functionally broken in Jest, so this shouldn't break jest tests. The change for jest is that the jsdom focus() and blur() methods are no longer patched, but they didn't need to be.

With the previous implementation, `focus()` and `blur()` worked partially in karma, but `document.activeElement` wasn't set by the patched methods. The old behavior ensured that focus and blur events were always sent when their respective methods were called, but it didn't handle blurring the previous activeElement. It also didn't set the activeElement. The new implementation calls the browser's `focus()` method, which seems to always set the `document.activeElement`, but doesn't always send focus/blur events depending on the browser state. The new patch listens for browser-emitted focus/blur events, and sends fake ones (same as before) if they weren't emitted by the browser.

It might be a good idea to call the browser's `blur()` method first, and send a blur event only if one doesn't occur. However I haven't had to deal with this possible inconsistency between test environments and browsers, so I didn't make this fix.
