### PR TITLE
fix: add code to KeyboardEvent

### DIFF
--- a/projects/spectator/src/lib/event-creators.ts
+++ b/projects/spectator/src/lib/event-creators.ts
@@ -72,6 +72,7 @@ export function createKeyboardEvent(type: string, keyOrKeyCode: string | number 
   // Webkit Browsers don't set the keyCode when calling the init function.
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
   Object.defineProperties(event, {
+    code: { get: () => keyCode },
     keyCode: { get: () => keyCode },
     key: { get: () => key },
     target: { get: () => target },

--- a/projects/spectator/test/events/events.component.html
+++ b/projects/spectator/test/events/events.component.html
@@ -5,5 +5,6 @@
        (keyup.control.shift.a)="onPressCtrlShiftA()"
        (keyup.dot)="onPressDot()"
        (keyup.arrowleft)="onPressArrowLeft($event)"
+       (keyup.arrowup)="onPressArrowUp($event)"
        (keyup.control.shift.arrowright)="onPressArrowRight($event)"
 >

--- a/projects/spectator/test/events/events.component.spec.ts
+++ b/projects/spectator/test/events/events.component.spec.ts
@@ -44,6 +44,11 @@ describe('EventsComponent', () => {
     expect(spectator.query('h1')).toHaveText('pressed ArrowLeft:40');
   });
 
+  it('should include key and code when KeyboardEventOptions are passed', () => {
+    spectator.dispatchKeyboardEvent('input', 'keyup', { key: 'ArrowUp', keyCode: 38 });
+    expect(spectator.query('h1')).toHaveText('pressed ArrowUp:38');
+  });
+
   it('should parse modifiers from KeyboardEventOptions.key', () => {
     spectator.dispatchKeyboardEvent('input', 'keyup', { key: 'ctrl.shift.ArrowRight', keyCode: 39 });
     expect(spectator.query('h1')).toHaveText('pressed ArrowRight:39');

--- a/projects/spectator/test/events/events.component.ts
+++ b/projects/spectator/test/events/events.component.ts
@@ -39,4 +39,8 @@ export class EventsComponent {
   public onPressArrowRight(event: KeyboardEvent): void {
     this.event = `pressed ArrowRight:${event.keyCode}`;
   }
+
+  public onPressArrowUp(event: KeyboardEvent): void {
+    this.event = `pressed ${event.key}:${event.code}`;
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
**code** property, which is favored over deprecated **keyCode** is not added to KeyboardEvent

Issue Number: #501 


## What is the new behavior?
**code** property is added to KeyboardEvent



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
