### PR TITLE
fix(startup error): update @testing-library/dom to update pretty-format

### DIFF
--- a/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -111,6 +111,20 @@ describe('DomSelectorsComponent', () => {
       });
     });
 
+    describe('with number matcher', () => {
+      it('should match number content', () => {
+        let element = spectator.query(byTextContent(8, { selector: '#number-content-root *' }));
+        expect(element).toHaveId('number-content-only-eight');
+      });
+
+      it('should partially match number with `exact: false`', () => {
+        let elements = spectator.queryAll(byTextContent(8, { selector: '#number-content-root *', exact: false }));
+        expect(elements).toHaveLength(2);
+        expect(elements[0]).toHaveId('number-content-with-eight');
+        expect(elements[1]).toHaveId('number-content-only-eight');
+      });
+    });
+
     describe('with RegExp matcher', () => {
       it('should match the text', () => {
         const element = spectator.query(byTextContent(/^some deeply NESTED TEXT$/, { selector: '#text-content-root' }));
@@ -143,5 +157,6 @@ describe('DomSelectorsComponent', () => {
         expect(element).toHaveId('text-content-span-2');
       });
     });
+
   });
 });

--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -23,7 +23,7 @@
     "angular testing dumb components"
   ],
   "dependencies": {
-    "@testing-library/dom": "7.26.5",
+    "@testing-library/dom": "^8.11.0",
     "jquery": "3.6.0",
     "replace-in-file": "6.2.0",
     "tslib": "^2.1.0"

--- a/projects/spectator/src/lib/dom-selectors.ts
+++ b/projects/spectator/src/lib/dom-selectors.ts
@@ -31,7 +31,7 @@ export const byText: DOMSelectorFactory<SelectorMatcherOptions> = (matcher, opti
 export const byTextContent = (matcher: Matcher, options: MandatorySelectorMatchingOptions): DOMSelector => {
   let textContentMatcher: Matcher;
   const normalizer: NormalizerFn = options?.normalizer || getDefaultNormalizer(options);
-  const getTextContent = (elem: HTMLElement): string => normalizer(elem.textContent ?? '');
+  const getTextContent = (elem: Element | null): string => normalizer(elem?.textContent ?? '');
 
   if (typeof matcher === 'string') {
     textContentMatcher = (_, elem) => {
@@ -47,8 +47,11 @@ export const byTextContent = (matcher: Matcher, options: MandatorySelectorMatchi
     };
   } else if (matcher instanceof RegExp) {
     textContentMatcher = (_, elem) => matcher.test(getTextContent(elem));
-  } else {
+  } else if (typeof matcher === 'function') {
     textContentMatcher = (_, elem) => matcher(getTextContent(elem), elem);
+  } else {
+    // number Matcher not supported
+    throw new Error(`Matcher type not supported: ${typeof matcher}`);
   }
 
   return new DOMSelector(el => DOMQueries.queryAllByText(el, textContentMatcher, options));

--- a/projects/spectator/src/lib/dom-selectors.ts
+++ b/projects/spectator/src/lib/dom-selectors.ts
@@ -33,24 +33,23 @@ export const byTextContent = (matcher: Matcher, options: MandatorySelectorMatchi
   const normalizer: NormalizerFn = options?.normalizer || getDefaultNormalizer(options);
   const getTextContent = (elem: Element | null): string => normalizer(elem?.textContent ?? '');
 
-  if (typeof matcher === 'string') {
+  if (typeof matcher === 'string' || typeof matcher === 'number') {
     textContentMatcher = (_, elem) => {
       if (options?.exact === false) {
         return (
           getTextContent(elem)
             .toLowerCase()
-            .indexOf(matcher.toLowerCase()) >= 0
+            .indexOf(matcher.toString().toLowerCase()) >= 0
         );
       }
 
-      return getTextContent(elem) === matcher;
+      return getTextContent(elem) === matcher.toString();
     };
   } else if (matcher instanceof RegExp) {
     textContentMatcher = (_, elem) => matcher.test(getTextContent(elem));
   } else if (typeof matcher === 'function') {
     textContentMatcher = (_, elem) => matcher(getTextContent(elem), elem);
   } else {
-    // number Matcher not supported
     throw new Error(`Matcher type not supported: ${typeof matcher}`);
   }
 

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
@@ -112,6 +112,20 @@ describe('DomSelectorsComponent', () => {
       });
     });
 
+    describe('with number matcher', () => {
+      it('should match number content', () => {
+        let element = spectator.query(byTextContent(8, { selector: '#number-content-root *' }));
+        expect(element).toHaveId('number-content-only-eight');
+      });
+
+      it('should partially match number with `exact: false`', () => {
+        let elements = spectator.queryAll(byTextContent(8, { selector: '#number-content-root *', exact: false }));
+        expect(elements).toHaveLength(2);
+        expect(elements[0]).toHaveId('number-content-with-eight');
+        expect(elements[1]).toHaveId('number-content-only-eight');
+      });
+    });
+
     describe('with RegExp matcher', () => {
       it('should match the text', () => {
         const element = spectator.query(byTextContent(/^some deeply NESTED TEXT$/, { selector: '#text-content-root' }));

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.ts
@@ -25,6 +25,11 @@ import { Component } from '@angular/core';
       </span>
     </div>
 
+    <div id="number-content-root">
+      <span id="number-content-with-eight"> to prevent #number-content-root having textContent: 8 </span>
+      <span id="number-content-only-eight">8</span>
+    </div>
+
     <div id="aria-checkboxes">
       <section>
         <button role="checkbox" aria-checked="true">Sugar</button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,10 +1457,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.3":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
-  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+"@babel/runtime@^7.12.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1937,6 +1937,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@jridgewell/resolve-uri@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz#3fdf5798f0b49e90155896f6291df186eac06c83"
@@ -2137,19 +2148,19 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/dom@7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.5.tgz#804a74fc893bf6da1a7970dbca7b94c2bbfe983d"
-  integrity sha512-2v/fv0s4keQjJIcD4bjfJMFtvxz5icartxUWdIZVNJR539WD9oxVrvIAPw+3Ydg4RLgxt0rvQx3L9cAjCci0Kg==
+"@testing-library/dom@^8.11.0":
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
+  integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.10.3"
+    "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.1"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
-    pretty-format "^26.4.2"
+    pretty-format "^27.0.2"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2870,6 +2881,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -4377,7 +4393,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.1:
+dom-accessibility-api@^0.5.9:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
   integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
@@ -8787,7 +8803,7 @@ pretty-bytes@^5.3.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-pretty-format@^26.0.0, pretty-format@^26.4.2, pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -8804,6 +8820,16 @@ pretty-format@^27.0.0, pretty-format@^27.0.6:
   dependencies:
     "@jest/types" "^27.0.6"
     ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
+  integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 


### PR DESCRIPTION
API change while updating to new @testing-library/dom

fixes: #519

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #519

## What is the new behavior?
Karma tests run without failure.

And: Matchers can now be numbers - a number matcher just matches number text, so the behavior is the same as if the matcher were `numberMatcher.toString()`. Because the change to the `Matcher` signature comes along with the dependency update required by this fix, the bug fix and exciting new feature come together.

## Does this PR introduce a breaking change?
```
[ x ] Yes
[] No
```

The breaking change will occur due to the change to `MatcherFunction` in `@testing-library/dom` - the MatcherFunction now passes in an `Element`, where it previously was `HTMLElement` - so users will have to test/cast to `HTMLElement` if they need `HTMLElement`-specific properties in their matcher function.

It's unfortunate that this change was added in a minor version of `@testing-library/dom`. Since spectator depends on this external interface that changed, there's no way (that I can find) to fix this major issue without taking the API change.

## Other information

The @testing-library/dom API changed a little, so I had to update `byTextContent()` to fix some typing errors - no issue there, the new API is less strict, so there should be no change to the spectator API.

The issue I found is that type `Matcher` can be a `number`, and if it is a `number` it would have thrown with the previous code. I added a check to prevent that error (also needed to compile), but I'm not sure what the correct behavior is for a `number` matcher, so I'm throwing an exception. If you'd like I can add tests to verify that an exception is thrown, but it's also possible that different behavior is expected if a `number` matcher is passed in. Please clarify what the correct behavior is.

edit: I removed the "throw error on number Matcher" and added support for number matchers in `byTextContent()`.
