### PR TITLE
fix(matchers): test css variables via getPropertyValue

### DIFF
--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -17,7 +17,7 @@ interface Dummy {
     <div style="visibility:hidden"><div id="parent-visibility-hidden">Hidden by parent with display none</div></div>
     <div id="visible">Visible</div>
     <div id="classes" class="class-a class-b">Classes</div>
-    <div id="styles" style="background-color: indianred; color: chocolate;"></div>
+    <div id="styles" style="background-color: indianred; color: chocolate; --primary: var(--black)"></div>
   `,
 })
 export class MatchersComponent {}
@@ -128,6 +128,11 @@ describe('Matchers', () => {
     it('should return true if all styles exist on element', () => {
       const element = spectator.query('#styles');
       expect(element).toHaveStyle({ 'background-color': 'indianred', color: 'chocolate' });
+    });
+
+    it('should return true if the CSS variable exist on element', () => {
+      const element = spectator.query('#styles');
+      expect(element).toHaveStyle({ '--primary': 'var(--black)' });
     });
 
     it('should return false if style exists on an element but has a different value than expected', () => {

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -65,7 +65,11 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
         continue;
       }
 
-      if (trim($el.get(0).style[prop]) !== trim(value) && trim(el.style[prop]) !== trim(value)) {
+      if (
+        trim($el.get(0).style[prop]) !== trim(value) &&
+        trim(el.style[prop]) !== trim(value) &&
+        trim(el.style.getPropertyValue(prop)) !== trim(value)
+      ) {
         return false;
       }
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently `toHaveStyle` doesn't detect CSS variables as they seem indexed by numbers:
![spectator](https://user-images.githubusercontent.com/260185/151880238-ff1a6c98-1b5b-45c1-ad42-6e24759acea7.png)

## What is the new behavior?

The matcher now is able to `pass` raw values for CSS variables.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Can this be cherry-picked and released in the `v8` branch please?
We're using Angular 12 and still using that version.