### PR TITLE
fix: unpatch `setTimeout` before importing jQuery so it is not captured by zone.js

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -1,7 +1,22 @@
 /** Credit: https://github.com/unindented/custom-jquery-matchers/tree/master/packages/custom-jquery-matchers */
 /* eslint-disable no-shadow, @typescript-eslint/no-shadow */
 
-import $ from 'jquery';
+// This is done to prevent tests, that are being run in a `fakeAsync` zone, from failing randomly.
+// jQuery setups a timer internally if the `document.readyState` is `complete` by doing
+// `window.setTimeout(jQuery.ready)` (see its source code). Unit tests might fail randomly that
+// there're still timers in the queue, but the timer has been scheduled by jQuery, so we don't
+// want to allow that to happen.
+const patchedSetTimeout = window.setTimeout;
+// The unpatched `setTimeout` can be retrieved through this property.
+// We might have used `Zone.__symbol__('OriginalDelegate')`, which would also give us
+// the current string, but accessing `Zone` requires messing up with types (like declaring it
+// globally through `declare const Zone`). This is the safest way of doing that.
+// This is done before importing jQuery since it will use the unpatched timer
+// when its code is executed, which will not be captured by zone.js.
+window.setTimeout = patchedSetTimeout['__zone_symbol__OriginalDelegate'] || patchedSetTimeout;
+// Note: do not use `import` since imports are hoisted during the compilation.
+const $ = require('jquery');
+window.setTimeout = patchedSetTimeout;
 
 import { hex2rgb, isHex, trim } from './internals/rgb-to-hex';
 import { isHTMLOptionElementArray, isObject } from './types';

--- a/projects/spectator/tsconfig.lib.json
+++ b/projects/spectator/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "inlineSources": true,
     "typeRoots" : ["./typings"],
-    "types": ["jasmine", "jest"],
+    "types": ["jasmine", "jest", "node"],
     "lib": [
       "dom",
       "es2018"


### PR DESCRIPTION
Hey Netanel.

I've been facing issues with `fakeAsync` and spectator during a long time, but I was thinking we're doing something wrong in unit tests. The issue has been happening so randomly, like in 1 of 10 cases, so I couldn't capture it. The tests were basically failing with `1 timer(s) still in the queue.`. So after debugging zone.js `onScheduleTask` I've found that the task, which is being scheduled, is `$.ready`.

See the code:
https://github.com/jquery/jquery/blob/5d5ea015114092c157311c4948f7cc3d8c8e7f8a/src/core/ready.js#L64-L70

I don't know if there's any other way to fix that issue and to force jquery **not** to schedule a timer. So I just unpatched the `setTimeout` before requiring jquery and then reset it back.