### PR TITLE
feat(matchers): add toBeIndeterminate matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ expect('.zippy__content').toContainValue(['value a', 'value b']);
 expect(spectator.element).toHaveStyle({backgroundColor: 'rgba(0, 0, 0, 0.1)'});
 expect('.zippy__content').toHaveData({data: 'role', val: 'admin'});
 expect('.checkbox').toBeChecked();
+expect('.checkbox').toBeIndeterminate();
 expect('.button').toBeDisabled();
 expect('div').toBeEmpty();
 expect('div').toBeHidden();

--- a/docs/docs/custom-matchers.md
+++ b/docs/docs/custom-matchers.md
@@ -31,6 +31,7 @@ expect('.zippy__content').toContainValue(['value a', 'value b']);
 expect(spectator.element).toHaveStyle({backgroundColor: 'rgba(0, 0, 0, 0.1)'});
 expect('.zippy__content').toHaveData({data: 'role', val: 'admin'});
 expect('.checkbox').toBeChecked();
+expect('.checkbox').toBeIndeterminate();
 expect('.button').toBeDisabled();
 expect('div').toBeEmpty();
 expect('div').toBeHidden();

--- a/projects/spectator/jest/src/lib/matchers-types.ts
+++ b/projects/spectator/jest/src/lib/matchers-types.ts
@@ -30,6 +30,8 @@ declare namespace jest {
 
     toBeChecked(): boolean;
 
+    toBeIndeterminate(): boolean;
+
     toBeDisabled(): boolean;
 
     toBeEmpty(): boolean;

--- a/projects/spectator/src/lib/matchers-types.ts
+++ b/projects/spectator/src/lib/matchers-types.ts
@@ -30,6 +30,8 @@ declare namespace jasmine {
 
     toBeChecked(): boolean;
 
+    toBeIndeterminate(): boolean;
+
     toBeDisabled(): boolean;
 
     toBeEmpty(): boolean;

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -333,6 +333,17 @@ export const toBeChecked = comparator((el) => {
 
 /**
  *
+ * expect('.checkbox').toBeIndeterminate();
+ */
+export const toBeIndeterminate = comparator((el) => {
+  const pass = $(el).is(':indeterminate');
+  const message = () => `Expected element${pass ? ' not' : ''} to be indeterminate`;
+
+  return { pass, message };
+});
+
+/**
+ *
  * expect('.checkbox').toBeDisabled();
  */
 export const toBeDisabled = comparator((el) => {

--- a/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
+++ b/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
@@ -83,4 +83,14 @@ describe('Matcher enhancements', () => {
       expect(spectator.component.dummyValue).not.toBePartial({ active: false });
     });
   });
+
+  describe('Checkbox', () => {
+    it('should match checkbox checked state', () => {
+      expect(spectator.query('.checkbox')).toBeChecked();
+    });
+
+    it('should match checkbox indeterminate state', () => {
+      expect(spectator.query('.checkbox-indeterminate')).toBeIndeterminate();
+    });
+  })
 });

--- a/projects/spectator/test/matchers/matcher-enhancements.component.ts
+++ b/projects/spectator/test/matchers/matcher-enhancements.component.ts
@@ -14,6 +14,7 @@ export interface Dummy {
     <input class="sample" value="test1" />
     <input class="sample" value="test2" />
     <input class="checkbox" type="checkbox" checked />
+    <input class="checkbox-indeterminate" type="checkbox" [indeterminate]="true" />
     <div id="attr-check" label="test label"></div>
     <img src="http://localhost:8080/assets/myimg.jpg" />
   `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Users have to write:
```typescript
expect('.checkbox').toHaveProperty('indeterminate', true);
```


## What is the new behavior?
Users will be able to write:
```typescript
expect('.checkbox').toBeIndeterminate();
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
