### PR TITLE
(fix): remove double space in matchers' messages

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -99,7 +99,7 @@ const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string)
       }
     });
 
-    const message = () => `Expected element${pass ? ' not' : ''} to have ${exact ? 'exact' : ''} text '${failing}', but had '${actual}'`;
+    const message = () => `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text '${failing}', but had '${actual}'`;
 
     return { pass, message };
   }
@@ -109,13 +109,13 @@ const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string)
   if (expected && typeof expected !== 'string') {
     const pass = expected(actual);
     const message = () =>
-      `Expected element${pass ? ' not' : ''} to have ${exact ? 'exact' : ''} text matching '${expected}',` + ` but had '${actual}'`;
+      `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text matching '${expected}',` + ` but had '${actual}'`;
 
     return { pass, message };
   }
 
   const pass = exact && !Array.isArray(expected) ? actual === expected : actual.indexOf(expected) !== -1;
-  const message = () => `Expected element${pass ? ' not' : ''} to have ${exact ? 'exact' : ''} text '${expected}', but had '${actual}'`;
+  const message = () => `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text '${expected}', but had '${actual}'`;
 
   return { pass, message };
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Matchers with `exact` argument have double spaces in their messages.

## What is the new behavior?

Messages without "typos".


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

There were no tests, verifying the error messages. If you find it necessary I can add them, otherwise this is a rather simple PR.