### PR TITLE
feat(dom-spectator): add query with root opt for Type selector

### DIFF
--- a/projects/spectator/jest/test/query-root/query-root.component.spec.ts
+++ b/projects/spectator/jest/test/query-root/query-root.component.spec.ts
@@ -1,0 +1,34 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+
+import { QueryRootComponent, QueryRootOverlayComponent } from '../../../test/query-root/query-root.component';
+
+describe('QueryRootComponent', () => {
+  let spectator: Spectator<QueryRootComponent>;
+  const createComponent = createComponentFactory(QueryRootComponent);
+
+  beforeEach(() => {
+    spectator = createComponent();
+  });
+
+  it('should allow querying one by directive', () => {
+    spectator.component.openOverlay();
+
+    const component = spectator.query(QueryRootOverlayComponent, { root: true });
+    expect(component?.title).toBe('Query Root Overlay');
+  });
+
+  it('should allow querying last by directive', () => {
+    spectator.component.openOverlay();
+
+    const component = spectator.queryLast(QueryRootOverlayComponent, { root: true });
+    expect(component?.title).toBe('Query Root Overlay');
+  });
+
+  it('should allow querying all by directive', () => {
+    spectator.component.openOverlay();
+
+    const components = spectator.queryAll(QueryRootOverlayComponent, { root: true });
+    expect(components.length).toBe(1);
+    expect(components[0].title).toBe('Query Root Overlay');
+  });
+});

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -35,8 +35,8 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   }
 
   public query<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
-  public query<R>(directive: Type<R>): R | null;
-  public query<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
+  public query<R>(directive: Type<R>, options?: { root: boolean }): R | null;
+  public query<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R>, root?: boolean }): R | null;
   public query<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
     if ((options || {}).root) {
       if (isString(directiveOrSelector)) {
@@ -46,14 +46,16 @@ export abstract class DomSpectator<I> extends BaseSpectator {
       if (directiveOrSelector instanceof DOMSelector) {
         return directiveOrSelector.execute(document as any)[0] || null;
       }
+
+      return getChildren<R>(this.getRootDebugElement())(directiveOrSelector, options)[0] || null;
     }
 
     return getChildren<R>(this.debugElement)(directiveOrSelector, options)[0] || null;
   }
 
   public queryAll<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R[];
-  public queryAll<R>(directive: Type<R>): R[];
-  public queryAll<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R[];
+  public queryAll<R>(directive: Type<R>, options?: { root: boolean }): R[];
+  public queryAll<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R>, root?: boolean }): R[];
   public queryAll<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R[] | Element[] {
     if ((options || {}).root) {
       if (isString(directiveOrSelector)) {
@@ -63,24 +65,26 @@ export abstract class DomSpectator<I> extends BaseSpectator {
       if (directiveOrSelector instanceof DOMSelector) {
         return directiveOrSelector.execute(document as any);
       }
+
+      return getChildren<R>(this.getRootDebugElement())(directiveOrSelector, options);
     }
 
     return getChildren<R>(this.debugElement)(directiveOrSelector, options);
   }
 
   public queryLast<R extends Element>(selector: string | DOMSelector, options?: { root: boolean }): R | null;
-  public queryLast<R>(directive: Type<R>): R | null;
-  public queryLast<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R> }): R | null;
+  public queryLast<R>(directive: Type<R>, options?: { root: boolean }): R | null;
+  public queryLast<R>(directiveOrSelector: Type<any> | string, options: { read: Token<R>, root?: boolean }): R | null;
   public queryLast<R>(directiveOrSelector: QueryType, options?: QueryOptions<R>): R | Element | null {
     let result: (R | Element)[] = [];
 
     if ((options || {}).root) {
       if (isString(directiveOrSelector)) {
         result = Array.from(document.querySelectorAll(directiveOrSelector));
-      }
-
-      if (directiveOrSelector instanceof DOMSelector) {
+      } else if (directiveOrSelector instanceof DOMSelector) {
         result = directiveOrSelector.execute(document as any);
+      } else {
+        result = getChildren<R>(this.getRootDebugElement())(directiveOrSelector, options);
       }
     } else {
       result = getChildren<R>(this.debugElement)(directiveOrSelector, options);

--- a/projects/spectator/test/query-root/query-root.component.spec.ts
+++ b/projects/spectator/test/query-root/query-root.component.spec.ts
@@ -1,0 +1,34 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+
+import { QueryRootComponent, QueryRootOverlayComponent } from './query-root.component';
+
+describe('QueryRootComponent', () => {
+  let spectator: Spectator<QueryRootComponent>;
+  const createComponent = createComponentFactory(QueryRootComponent);
+
+  beforeEach(() => {
+    spectator = createComponent();
+  });
+
+  it('should allow querying one by directive', () => {
+    spectator.component.openOverlay();
+
+    const component = spectator.query(QueryRootOverlayComponent, { root: true });
+    expect(component?.title).toBe('Query Root Overlay');
+  });
+
+  it('should allow querying last by directive', () => {
+    spectator.component.openOverlay();
+
+    const component = spectator.queryLast(QueryRootOverlayComponent, { root: true });
+    expect(component?.title).toBe('Query Root Overlay');
+  });
+
+  it('should allow querying all by directive', () => {
+    spectator.component.openOverlay();
+
+    const components = spectator.queryAll(QueryRootOverlayComponent, { root: true });
+    expect(components.length).toBe(1);
+    expect(components[0].title).toBe('Query Root Overlay');
+  });
+});

--- a/projects/spectator/test/query-root/query-root.component.ts
+++ b/projects/spectator/test/query-root/query-root.component.ts
@@ -1,0 +1,63 @@
+import { Overlay, OverlayModule } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-query-root',
+  standalone: true,
+  imports: [OverlayModule],
+  template: `
+    <p id="by-text-p">By text</p>
+    <p id="by-text-p-2">By text</p>
+
+    <label for="by-label-input">By label</label>
+    <input type="text" id="by-label-input" />
+
+    <input type="text" placeholder="By placeholder" id="by-placeholder-input" />
+
+    <img src="" alt="By alt text" id="by-alt-text-img" />
+
+    <a href="" title="By title" id="by-title-a"></a>
+
+    <input type="text" value="By value" id="by-value-input" />
+
+    <div id="text-content-root">
+      <span> some </span>
+      <span>
+        <span id="text-content-span-1"><span>deeply</span><span>&ngsp;</span><span>&ngsp;</span>NESTED</span>
+        <span id="text-content-span-2"> TEXT </span>
+      </span>
+    </div>
+
+    <div id="number-content-root">
+      <span id="number-content-with-eight"> to prevent #number-content-root having textContent: 8 </span>
+      <span id="number-content-only-eight">8</span>
+    </div>
+
+    <div id="aria-checkboxes">
+      <section>
+        <button role="checkbox" aria-checked="true">Sugar</button>
+        <button role="checkbox" aria-checked="false">Gummy bears</button>
+        <button role="checkbox" aria-checked="false">Whipped cream</button>
+      </section>
+    </div>
+  `,
+})
+export class QueryRootComponent {
+  public constructor(private overlay: Overlay) {}
+
+  public openOverlay(): void {
+    const componentPortal = new ComponentPortal(QueryRootOverlayComponent);
+    const overlayRef = this.overlay.create();
+    overlayRef.attach(componentPortal);
+  }
+}
+
+@Component({
+  selector: 'app-query-root-overlay',
+  standalone: true,
+  template: ` <p>{{ title }}</p> `,
+})
+export class QueryRootOverlayComponent {
+  public title = 'Query Root Overlay';
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using `spectator.query()`, you can use `{ root: true }` in order to query an element inside an overlay. But what if you want to query a `SomeModalContentComponent` inside an overlay ?

You cannot do `spectator.query(SomeModalContentComponent, { root: true })`.

Issue Number: 0


## What is the new behavior?

You can now query for components in a global way with `spectator.query(SomeModalContentComponent, { root: true })`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
