### PR TITLE
fix(matchers): prevent crash on elements in a Shadow DOM

### DIFF
--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -434,7 +434,7 @@ function isHidden(elOrSelector: HTMLElement | string): boolean {
       return true;
     }
 
-    el = el.parentNode;
+    el = el.parentNode || el.host;
   }
 
   return false;

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -430,7 +430,7 @@ function isHidden(elOrSelector: HTMLElement | string): boolean {
       break;
     }
 
-    if (hiddenWhen.some((rule) => rule(el))) {
+    if (el.nodeType === Node.ELEMENT_NODE && hiddenWhen.some((rule) => rule(el))) {
       return true;
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- N/A Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When passing an element within a shadow dom into toBeVisible/toBeHidden, it is possible that the element which causes that element to be hidden is outside the shadow dom containing the element; in that case, it will crash with this error when it attempts to call getClientRects on the Shadow DOM node (which is a DocumentFragment, not an Element):

```
TypeError: el.getClientRects is not a function
    at rule (node_modules/@ngneat/spectator/fesm2020/ngneat-spectator.mjs:1041:59)
    at some (node_modules/@ngneat/spectator/fesm2020/ngneat-spectator.mjs:1056:39)
    at Array.some (<anonymous>)
    at isHidden (node_modules/@ngneat/spectator/fesm2020/ngneat-spectator.mjs:1056:24)
    at node_modules/@ngneat/spectator/fesm2020/ngneat-spectator.mjs:1102:19
    at <Jasmine>
```

Issue Number: N/A


## What is the new behavior?

It doesn't crash and works as expected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
