### PR TITLE
feat: allow erroring on unknown elements/properties

### DIFF
--- a/docs/docs/global-injections.md
+++ b/docs/docs/global-injections.md
@@ -1,6 +1,6 @@
 ---
 id: global-injections
-title: Global Injections 
+title: Global Injections
 ---
 
 It's possible to define injections which will be available for each test without the need to re-declare them in each test:

--- a/docs/docs/testing-components.md
+++ b/docs/docs/testing-components.md
@@ -47,6 +47,8 @@ const createComponent = createComponentFactory({
   declareComponent: false, // Defaults to true
   disableAnimations: false, // Defaults to true
   shallow: true, // Defaults to false
+  errorOnUnknownElements: true, // Defaults to false
+  errorOnUnknownProperties: true, // Defaults to false
 });
 ```
 

--- a/projects/spectator/src/lib/base/initial-module.ts
+++ b/projects/spectator/src/lib/base/initial-module.ts
@@ -16,6 +16,8 @@ export interface ModuleMetadata {
   entryComponents: Type<any>[];
   schemas?: (SchemaMetadata | any[])[];
   teardown?: ModuleTeardownOptions;
+  errorOnUnknownElements: boolean;
+  errorOnUnknownProperties: boolean;
 }
 
 /**
@@ -34,5 +36,7 @@ export function initialModule(options: Required<BaseSpectatorOptions>): ModuleMe
       // is always defined. If the user calls `defineGlobalsInjections({ teardown: { ... } })` and we merge it with
       // `options.teardown`, then `options.teardown` will always override global options.
       { ...(globals.teardown || options.teardown) },
+    errorOnUnknownElements: globals.errorOnUnknownElements || options.errorOnUnknownElements,
+    errorOnUnknownProperties: globals.errorOnUnknownProperties || options.errorOnUnknownProperties,
   };
 }

--- a/projects/spectator/src/lib/base/options.ts
+++ b/projects/spectator/src/lib/base/options.ts
@@ -19,6 +19,8 @@ export interface BaseSpectatorOptions {
   schemas?: (SchemaMetadata | any[])[];
   overrideModules?: [Type<any>, MetadataOverride<NgModule>][];
   teardown?: ModuleTeardownOptions;
+  errorOnUnknownElements?: boolean;
+  errorOnUnknownProperties?: boolean;
 }
 
 /**
@@ -38,7 +40,9 @@ const defaultOptions: OptionalsRequired<BaseSpectatorOptions> = {
   imports: [],
   schemas: [],
   overrideModules: [],
-  teardown: { destroyAfterEach: false }
+  teardown: { destroyAfterEach: false },
+  errorOnUnknownElements: false,
+  errorOnUnknownProperties: false,
 };
 
 /**

--- a/projects/spectator/src/lib/spectator/options.ts
+++ b/projects/spectator/src/lib/spectator/options.ts
@@ -26,7 +26,7 @@ const defaultSpectatorOptions: OptionalsRequired<SpectatorOptions<any>> = {
   componentProviders: [],
   componentViewProviders: [],
   componentMocks: [],
-  componentViewProvidersMocks: []
+  componentViewProvidersMocks: [],
 };
 
 /**

--- a/projects/spectator/test/error-unknown/error-unknown-element.component.spec.ts
+++ b/projects/spectator/test/error-unknown/error-unknown-element.component.spec.ts
@@ -1,0 +1,17 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { CommonModule } from '@angular/common';
+
+import { ErrorUnknownElementComponent } from './error-unknown-element.component';
+
+describe('ErrorUnknownElementComponent', () => {
+  const createComponent = createComponentFactory({
+    component: ErrorUnknownElementComponent,
+    imports: [CommonModule],
+    errorOnUnknownElements: true,
+  });
+
+  it('should throw an error when creating the component', () => {
+    expect(() => createComponent()).toThrowError();
+  });
+
+});

--- a/projects/spectator/test/error-unknown/error-unknown-element.component.ts
+++ b/projects/spectator/test/error-unknown/error-unknown-element.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+/* eslint-disable @angular-eslint/template/no-call-expression */
+
+@Component({
+  selector: 'app-use-unknown-element',
+  template: `<some-element></some-element>`,
+})
+export class ErrorUnknownElementComponent {
+
+}

--- a/projects/spectator/test/error-unknown/error-unknown-property.component.spec.ts
+++ b/projects/spectator/test/error-unknown/error-unknown-property.component.spec.ts
@@ -1,0 +1,17 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { CommonModule } from '@angular/common';
+
+import { ErrorUnknownPropertyComponent } from './error-unknown-property.component';
+
+describe('ErrorUnknownPropertyComponent', () => {
+  const createComponent = createComponentFactory({
+    component: ErrorUnknownPropertyComponent,
+    imports: [CommonModule],
+    errorOnUnknownProperties: true,
+  });
+
+  it('should throw an error when creating the component', () => {
+    expect(() => createComponent()).toThrowError();
+  });
+
+});

--- a/projects/spectator/test/error-unknown/error-unknown-property.component.ts
+++ b/projects/spectator/test/error-unknown/error-unknown-property.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+/* eslint-disable @angular-eslint/template/no-call-expression */
+
+@Component({
+  selector: 'app-use-unknown-property',
+  template: `<span [some-property]="true"></span>`,
+})
+export class ErrorUnknownPropertyComponent {
+
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/spectator/issues/575

When unknown elements or properties are used, it is just logged to stdout.

## What is the new behavior?
Allows failing test when unknown elements or properties are used

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
