### PR TITLE
feat(matchers): add toHaveExactTrimmedText matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,7 @@ expect('.zippy__content').toHaveClass(['class-b', 'class-a'], { strict: false })
 expect('.zippy__content').toHaveClass(['class-b', 'class-a'], { strict: false });
 
 // Note that toHaveText only looks for the existence of a string, not if the string is exactly the same. If you want to verify that the string is completely the same, use toHaveExactText.
+// Note that if you want to verify that the string is completely the same, but trimmed first, use toHaveExactTrimmedText.
 // Note that if you pass multiple values, Spectator checks the text of each array element against the index of the element found. 
 expect('.zippy__content').toHaveText('Content');
 expect('.zippy__content').toHaveText(['Content A', 'Content B']);
@@ -1219,6 +1220,8 @@ expect('.zippy__content').toContainText('Content');
 expect('.zippy__content').toContainText(['Content A', 'Content B']);
 expect('.zippy__content').toHaveExactText('Content');
 expect('.zippy__content').toHaveExactText(['Content A', 'Content B']);
+expect('.zippy__content').toHaveExactTrimmedText('Content');
+expect('.zippy__content').toHaveExactTrimmedText(['Content A', 'Content B']);
 expect('.zippy__content').toHaveValue('value');
 expect('.zippy__content').toContainValue('value');
 

--- a/projects/spectator/jest/src/lib/matchers-types.ts
+++ b/projects/spectator/jest/src/lib/matchers-types.ts
@@ -18,7 +18,9 @@ declare namespace jest {
 
     toContainText(text: string | string[] | ((text: string) => boolean), exact?: boolean): boolean;
 
-    toHaveExactText(text: string | string[] | ((text: string) => boolean)): boolean;
+    toHaveExactText(text: string | string[] | ((text: string) => boolean), options?: {trim: boolean}): boolean;
+
+    toHaveExactTrimmedText(text: string | string[] | ((text: string) => boolean)): boolean;
 
     toHaveValue(value: string | string[]): boolean;
 

--- a/projects/spectator/jest/test/hello/hello.component.spec.ts
+++ b/projects/spectator/jest/test/hello/hello.component.spec.ts
@@ -27,5 +27,14 @@ describe('HelloComponent', () => {
     expect('div h1').toHaveExactText('some title');
     expect('div h1').not.toHaveExactText('ome title');
     expect('div h1').not.toHaveExactText('');
+
+    expect('div h2').toHaveText(' some title ', true);
+
+    expect('div h2').toHaveExactText(' some title ');
+    expect('div h2').toHaveExactText('some title', {trim: true});
+    expect('div h2').not.toHaveExactText('ome title', {trim: true});
+
+    expect('div h2').toHaveExactTrimmedText('some title');
+    expect('div h2').not.toHaveExactTrimmedText('ome title');
   });
 });

--- a/projects/spectator/src/lib/matchers-types.ts
+++ b/projects/spectator/src/lib/matchers-types.ts
@@ -18,7 +18,9 @@ declare namespace jasmine {
 
     toContainText(text: string | string[] | ((text: string) => boolean), exact?: boolean): boolean;
 
-    toHaveExactText(text: string | string[] | ((text: string) => boolean)): boolean;
+    toHaveExactText(text: string | string[] | ((text: string) => boolean), options?: {trim: boolean}): boolean;
+
+    toHaveExactTrimmedText(text: string | string[] | ((text: string) => boolean)): boolean;
 
     toHaveValue(value: string | string[]): boolean;
 

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -83,15 +83,18 @@ const hasCss = (el: HTMLElement, css: { [key: string]: string }) => {
   return true;
 };
 
-const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string) => boolean), exact = false) => {
+const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string) => boolean), options: {
+  exact: boolean;
+  trim: boolean;
+}) => {
   if (expected && Array.isArray(expected)) {
     let actual: string;
     let pass = false;
     let failing: string;
 
     $(el).each((i, e) => {
-      actual = exact ? $(e).text() : $.trim($(e).text());
-      pass = exact ? actual === expected[i] : actual.includes(expected[i]);
+      actual = options.exact && !options.trim ? $(e).text() : $.trim($(e).text());
+      pass = options.exact ? actual === expected[i] : actual.includes(expected[i]);
       if (!pass) {
         failing = expected[i];
 
@@ -99,23 +102,23 @@ const hasSameText = (el: HTMLElement, expected: string | string[] | ((s: string)
       }
     });
 
-    const message = () => `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text '${failing}', but had '${actual}'`;
+    const message = () => `Expected element${pass ? ' not' : ''} to have${options.exact ? ' exact' : ''} text '${failing}', but had '${actual}'`;
 
     return { pass, message };
   }
 
-  const actual = exact ? $(el).text() : $.trim($(el).text());
+  const actual = options.exact && !options.trim ? $(el).text() : $.trim($(el).text());
 
   if (expected && typeof expected !== 'string') {
     const pass = expected(actual);
     const message = () =>
-      `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text matching '${expected}',` + ` but had '${actual}'`;
+      `Expected element${pass ? ' not' : ''} to have${options.exact ? ' exact' : ''} text matching '${expected}',` + ` but had '${actual}'`;
 
     return { pass, message };
   }
 
-  const pass = exact && !Array.isArray(expected) ? actual === expected : actual.indexOf(expected) !== -1;
-  const message = () => `Expected element${pass ? ' not' : ''} to have${exact ? ' exact' : ''} text '${expected}', but had '${actual}'`;
+  const pass = options.exact && !Array.isArray(expected) ? actual === expected : actual.indexOf(expected) !== -1;
+  const message = () => `Expected element${pass ? ' not' : ''} to have${options.exact ? ' exact' : ''} text '${expected}', but had '${actual}'`;
 
   return { pass, message };
 };
@@ -253,9 +256,11 @@ export const toContainProperty = comparator((el, prop, val) => {
  *
  * expect('.zippy__content').toHaveText((text) => text.includes('..');
  */
-export const toHaveText = comparator((el, expected, exact = false) => hasSameText(el, expected, exact));
+export const toHaveText = comparator((el, expected, exact = false) => hasSameText(el, expected, {exact, trim: false}));
 
-export const toHaveExactText = comparator((el, expected) => hasSameText(el, expected, true));
+export const toHaveExactText = comparator((el, expected, options: {trim: boolean} = {trim: false}) => hasSameText(el, expected, {exact: true, trim: options.trim}));
+
+export const toHaveExactTrimmedText = comparator((el, expected) => hasSameText(el, expected, {exact: true, trim: true}));
 
 export const toContainText = toHaveText;
 

--- a/projects/spectator/test/hello/hello.component.spec.ts
+++ b/projects/spectator/test/hello/hello.component.spec.ts
@@ -34,5 +34,14 @@ describe('HelloComponent', () => {
     expect('div h1').toHaveExactText('some title');
     expect('div h1').not.toHaveExactText('ome title');
     expect('div h1').not.toHaveExactText('');
+
+    expect('div h2').toHaveText(' some title ', true);
+
+    expect('div h2').toHaveExactText(' some title ');
+    expect('div h2').toHaveExactText('some title', {trim: true});
+    expect('div h2').not.toHaveExactText('ome title', {trim: true});
+
+    expect('div h2').toHaveExactTrimmedText('some title');
+    expect('div h2').not.toHaveExactTrimmedText('ome title');
   });
 });

--- a/projects/spectator/test/hello/hello.component.ts
+++ b/projects/spectator/test/hello/hello.component.ts
@@ -7,6 +7,9 @@ import { TranslateService } from '../translate.service';
   template: `
     <div [style.width]="width" style="display: flex;">
       <h1>{{ title | translate }}</h1>
+      <h2>
+        {{ title | translate }}
+      </h2>
     </div>
 
     <div *ngIf="!widthRaw" style="color:red">widthRaw is not set</div>

--- a/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
+++ b/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
@@ -12,10 +12,12 @@ describe('Matcher enhancements', () => {
 
   describe('Text', () => {
     it('should match multiple elements with different text', () => {
-      const el = spectator.query('.text-check');
-      expect(el).toHaveText(['It should', 'different text']);
-      expect(el).toContainText(['It should', 'different text']);
-      expect(el).toHaveExactText(['It should have', 'Some different text']);
+      const el = spectator.queryAll('.text-check');
+      expect(el).toHaveText(['It should', 'different text', 'another']);
+      expect(el).toContainText(['It should', 'different text', 'another']);
+      expect(el).toHaveExactText(['It should have', 'Some different text', ' And another one ']);
+      expect(el).toHaveExactText(['It should have', 'Some different text', 'And another one'], {trim: true});
+      expect(el).toHaveExactTrimmedText(['It should have', 'Some different text', 'And another one']);
     });
   });
 

--- a/projects/spectator/test/matchers/matcher-enhancements.component.ts
+++ b/projects/spectator/test/matchers/matcher-enhancements.component.ts
@@ -10,6 +10,9 @@ export interface Dummy {
   template: `
     <div class="text-check">It should have</div>
     <div class="text-check">Some different text</div>
+    <div class="text-check">
+      And another one
+    </div>
     <div class="one-class two-class" id="multi-class"></div>
     <input class="sample" value="test1" />
     <input class="sample" value="test2" />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #568 


## What is the new behavior?
- `toHaveExactText` matcher accepts a second parameter that allows to trim actual text value before being checked, e.g. `    expect(element).toHaveExactText('some text', true);`
- `toHaveExactTrimmedText` matcher is added as a convenient shorthand for the above


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
