### PR TITLE
fix(dom-selectors): `byRole` typings

### DIFF
--- a/projects/spectator/src/lib/dom-selectors.ts
+++ b/projects/spectator/src/lib/dom-selectors.ts
@@ -1,5 +1,6 @@
 import {
   Matcher,
+  MatcherFunction,
   MatcherOptions,
   NormalizerFn,
   SelectorMatcherOptions,
@@ -7,6 +8,7 @@ import {
   getDefaultNormalizer,
   ByRoleOptions
 } from '@testing-library/dom';
+import { ARIARole } from 'aria-query';
 
 interface MandatorySelectorMatchingOptions extends MatcherOptions {
   selector: SelectorMatcherOptions['selector'];
@@ -66,5 +68,5 @@ export const byTestId: DOMSelectorFactory = (matcher, options) => new DOMSelecto
 export const byValue: DOMSelectorFactory = (matcher, options) =>
   new DOMSelector(el => DOMQueries.queryAllByDisplayValue(el, matcher, options));
 
-export const byRole: DOMSelectorFactory<ByRoleOptions> = (matcher, options) =>
+export const byRole = (matcher: ARIARole | MatcherFunction | Omit<string, ARIARole>, options?: ByRoleOptions): DOMSelector =>
   new DOMSelector(el => DOMQueries.queryAllByRole(el, matcher, options));


### PR DESCRIPTION
Add proper typings to `byRole` to get role autocomplete

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #589 


## What is the new behavior?

Updated the `byRole` typings to provide role autocomplete.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
