### PR TITLE
fix(spectator): make mock template type safe (#607)

### DIFF
--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -55,9 +55,9 @@ export function installProtoMethods<T>(mock: any, proto: any, createSpyFn: Funct
       mock[key] = createSpyFn(key);
     } else if (descriptor.get && !mock.hasOwnProperty(key)) {
       Object.defineProperty(mock, key, {
-        set: value => (mock[`_${key}`] = value),
+        set: (value) => (mock[`_${key}`] = value),
         get: () => mock[`_${key}`],
-        configurable: true
+        configurable: true,
       });
     }
   }
@@ -70,13 +70,13 @@ export function installProtoMethods<T>(mock: any, proto: any, createSpyFn: Funct
 /**
  * @publicApi
  */
-export function createSpyObject<T>(type: Type<T> | AbstractType<T>, template?: Partial<Record<keyof T, any>>): SpyObject<T> {
+export function createSpyObject<T>(type: Type<T> | AbstractType<T>, template?: Partial<T>): SpyObject<T> {
   const mock: any = { ...template } || {};
 
-  installProtoMethods<T>(mock, type.prototype, name => {
+  installProtoMethods<T>(mock, type.prototype, (name) => {
     const newSpy: jasmine.Spy & Partial<CompatibleSpy> = jasmine.createSpy(name);
     newSpy.andCallFake = (fn: (...args: any[]) => any) => <any>newSpy.and.callFake(fn);
-    newSpy.andReturn = val => newSpy.and.returnValue(val);
+    newSpy.andReturn = (val) => newSpy.and.returnValue(val);
     newSpy.reset = () => newSpy.calls.reset();
     // revisit return null here (previously needed for rtts_assert).
     newSpy.and.returnValue(null);
@@ -90,10 +90,10 @@ export function createSpyObject<T>(type: Type<T> | AbstractType<T>, template?: P
 /**
  * @publicApi
  */
-export function mockProvider<T>(type: Type<T> | AbstractType<T>, properties?: Partial<Record<keyof T, any>>): FactoryProvider {
+export function mockProvider<T>(type: Type<T> | AbstractType<T>, properties?: Partial<T>): FactoryProvider {
   return {
     provide: type,
-    useFactory: () => createSpyObject(type, properties)
+    useFactory: () => createSpyObject(type, properties),
   };
 }
 

--- a/projects/spectator/src/lib/spectator-routing/initial-module.ts
+++ b/projects/spectator/src/lib/spectator-routing/initial-module.ts
@@ -14,14 +14,15 @@ import { RouterStub } from './router-stub';
  */
 export function initialRoutingModule<S>(options: Required<SpectatorRoutingOptions<S>>): ModuleMetadata {
   const moduleMetadata = initialSpectatorModule(options);
+  const eventsSubject = new Subject<Event>();
 
   if (options.stubsEnabled) {
     moduleMetadata.imports.push(RouterTestingModule);
     moduleMetadata.providers.push(
       options.mockProvider(RouterStub, {
-        events: new Subject<Event>(),
+        events: eventsSubject.asObservable(),
         emitRouterEvent(event: Event): void {
-          this.events.next(event);
+          eventsSubject.next(event);
         },
         serializeUrl(): string {
           return '/';


### PR DESCRIPTION
BREAKING CHANGE: introducing type safety for the template values in createSpyObject and mockProvider. This might cause breaking builds because the compiler will find issues hidden until now.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other... Please describe: Stronger type checks for test mock implementation.
```

## What is the current behavior?
Weak type checking when mocking services, only checking the template keys, not the values types.

Issue Number: #607 


## What is the new behavior?
The TS compiler will show up mismatches between the service template values and the actual service methods.

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Introducing type safety for the template values in createSpyObject and mockProvider. This might cause breaking builds
because the compiler will find issues hidden until now.

## Other information
