### PR TITLE
feat(components): allow overriding more providers in createComponent

### DIFF
--- a/projects/spectator/jest/test/providers.spec.ts
+++ b/projects/spectator/jest/test/providers.spec.ts
@@ -1,0 +1,81 @@
+import { Component, Injectable, InjectionToken, OnInit, inject, makeEnvironmentProviders } from '@angular/core';
+import { createComponentFactory } from '@ngneat/spectator';
+
+@Injectable()
+class SomeService {
+  public getFoo(): string {
+    return 'original-foo';
+  }
+}
+
+const provideSomeService = () => makeEnvironmentProviders([SomeService]);
+
+const MOCKED_FOO = new InjectionToken<string>('MOCKED_FOO');
+
+@Injectable()
+class SomeMockService {
+  mockedFoo = inject(MOCKED_FOO);
+
+  public getFoo(): string {
+    return this.mockedFoo;
+  }
+}
+
+const provideSomeServiceTesting = (customFooValue?: string) =>
+  makeEnvironmentProviders([
+    { provide: MOCKED_FOO, useValue: customFooValue ?? 'mocked-foo' },
+    { provide: SomeMockService, useClass: SomeMockService },
+    { provide: SomeService, useExisting: SomeMockService },
+  ]);
+
+@Component({
+  selector: 'some-component',
+  template: ``,
+})
+export class SomeComponent implements OnInit {
+  public foo!: string;
+
+  private readonly someService = inject(SomeService);
+
+  public ngOnInit(): void {
+    this.foo = this.someService.getFoo();
+  }
+}
+
+describe('SomeComponent', () => {
+  describe('without mocking', () => {
+    const createComponent = createComponentFactory({ component: SomeComponent, providers: [provideSomeService()] });
+
+    it('should have original foo', () => {
+      const spectator = createComponent();
+      expect(spectator.component.foo).toBe('original-foo');
+    });
+  });
+
+  describe('with overriding factory providers', () => {
+    const createComponent = createComponentFactory({ component: SomeComponent, providers: [provideSomeServiceTesting()] });
+
+    it('should have mocked foo', () => {
+      const spectator = createComponent();
+      expect(spectator.component.foo).toBe('mocked-foo');
+    });
+  });
+
+  describe('with overriding createComponent providers', () => {
+    const createComponent = createComponentFactory({ component: SomeComponent, providers: [provideSomeService()] });
+
+    it('should have mocked foo', () => {
+      const spectator = createComponent({ providers: [provideSomeServiceTesting()] });
+      expect(spectator.component.foo).toBe('mocked-foo');
+    });
+  });
+
+  describe('with overriding factory & createComponent providers', () => {
+    const createComponent = createComponentFactory({ component: SomeComponent, providers: [provideSomeServiceTesting()] });
+
+    it('should have mocked foo', () => {
+      const spectator = createComponent({ providers: [provideSomeServiceTesting('other-mocked-foo')] });
+      expect(spectator.component.foo).toBe('other-mocked-foo');
+    });
+  });
+});

--- a/projects/spectator/src/lib/base/options.ts
+++ b/projects/spectator/src/lib/base/options.ts
@@ -1,4 +1,4 @@
-import {Component, Directive, NgModule, Pipe, Provider, SchemaMetadata, Type} from '@angular/core';
+import { Component, Directive, EnvironmentProviders, NgModule, Pipe, Provider, SchemaMetadata, Type } from '@angular/core';
 import { MetadataOverride, ModuleTeardownOptions } from '@angular/core/testing';
 
 import { merge } from '../internals/merge';
@@ -30,7 +30,7 @@ export interface BaseSpectatorOptions {
  * @internal
  */
 export interface BaseSpectatorOverrides {
-  providers?: Provider[];
+  providers?: (Provider | EnvironmentProviders)[];
 }
 
 const defaultOptions: OptionalsRequired<BaseSpectatorOptions> = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In our codebase we often provide mock versions of services (like a mock store) like so:
```ts
const createComponent = createComponentFactory({ component: SomeComponent, providers: [provideSomeServiceTesting('foo')] });
```
Where `foo` could be something like an initial state we pass into the mock store.

In individual tests, we would want to pass in a different initial state, like so:
```ts
const spectator = createComponent({ providers: [provideSomeServiceTesting('bar')] });
```

At the moment, with the way Spectator calls `TestBed.overrideProvider`, this is not possible depending on the shape of our `provideSomeServiceTesting`-function.

`TestBed.overrideProvider` accepts a few signatures (basically `useFactory` & `useValue`), meaning we can not provide the following:

```ts
[
  { provide: SomeMockService, useClass: SomeMockService },
  { provide: SomeService, useExisting: SomeMockService },
]
```

If we try this, an error gets thrown when we call `TestBed.overrideProvider` ([see this line](https://github.com/ngneat/spectator/blob/master/projects/spectator/src/lib/spectator/create-factory.ts#L149))


As a semi-separate issue, we can not use `EnvironmentProviders` even though Angular's signature for `providers` is `Array<Provider | EnvironmentProviders>`.

Issue Number: N/A


## What is the new behavior?

### Providers with useClass & useExisting are transformed internally when used to override providers

Since `TestBed.overrideProvider` doesn't accept all `Provider` signatures, I propose mapping them internally in Spectator to supported signatures. For example:
```ts
if ('useClass' in provider) {
  TestBed.overrideProvider(provider.provide, { useFactory: () => new provider.useClass() });
}
```

### Overriding EnvironmentProviders are supported

This does use an internal Angular API which I don't like, but I also haven't found another way to do this:
```ts
if ('ɵproviders' in provider) {
  const providers = (provider as ɵInternalEnvironmentProviders).ɵproviders;
  providers.flat().forEach((subProvider) => {
    overrideProvider(subProvider);
  });
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

I don't believe this introduces a breaking change, and have run Spectator with my changes over our repo without issues, but would appreciate someone with more background in the repo to confirm this.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
