### PR TITLE
fix: use computed styles to determine hidden-ness

### DIFF
--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -19,6 +19,16 @@ interface Dummy {
     <div id="classes" class="class-a class-b">Classes</div>
     <div id="styles" style="background-color: indianred; color: chocolate; --primary: var(--black)"></div>
     <custom-element style="visibility: hidden"></custom-element>
+    <style>
+      #css-visibiility {
+        visibility: hidden;
+      }
+      #css-display {
+        display: none;
+      }
+    </style>
+    <div id="css-visibility"></div>
+    <div id="css-display"></div>
   `,
 })
 export class MatchersComponent {}
@@ -120,6 +130,14 @@ describe('Matchers', () => {
       expect(
         document.querySelector('custom-element')?.shadowRoot?.querySelector("#shadow-dom")
       ).toBeHidden();
+    });
+
+    it('should detect elements with visibility: hidden set through CSS', () => {
+      expect(document.querySelector('#css-display')).toBeHidden();
+    });
+
+    it('should detect elements with display: none set through CSS', () => {
+      expect(document.querySelector('#css-visibility')).toBeHidden();
     });
   });
 

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -425,8 +425,8 @@ function isHidden(elOrSelector: HTMLElement | string): boolean {
 
   const hiddenWhen = [
     (el) => !(el.offsetWidth || el.offsetHeight || el.getClientRects().length),
-    (el) => el.style.display === 'none',
-    (el) => el.style.visibility === 'hidden',
+    (el) => window.getComputedStyle(el).display == 'none',
+    (el) => window.getComputedStyle(el).visibility == 'hidden',
     (el) => el.type === 'hidden',
     (el) => el.hasAttribute('hidden'),
   ];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- N/A Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, hidden-ness of an element is determined only by styles that are set via an element's `style` property, when many elements are instead styled by CSS. Using computed styles catches those cases in addition to the `style` property.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
