### PR TITLE
fix(matchers): use computed styles to determine hidden-ness

### DIFF
--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -19,6 +19,7 @@ interface Dummy {
     <div id="classes" class="class-a class-b">Classes</div>
     <div id="styles" style="background-color: indianred; color: chocolate; --primary: var(--black)"></div>
     <custom-element style="visibility: hidden"></custom-element>
+    <div id="computed-style"></div>
   `,
 })
 export class MatchersComponent {}
@@ -120,6 +121,16 @@ describe('Matchers', () => {
       expect(
         document.querySelector('custom-element')?.shadowRoot?.querySelector("#shadow-dom")
       ).toBeHidden();
+    });
+
+    it('should detect elements whose computed styles are display: none', () => {
+      window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'display' && 'none' });
+      expect(document.querySelector('#computed-style')).toBeHidden();
+    });
+
+    it('should detect elements whose computed styles are visibility: hidden', () => {
+      window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'visibility' && 'hidden' });
+      expect(document.querySelector('#computed-style')).toBeHidden();
     });
   });
 

--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -126,11 +126,15 @@ describe('Matchers', () => {
     it('should detect elements whose computed styles are display: none', () => {
       window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'display' && 'none' });
       expect(document.querySelector('#computed-style')).toBeHidden();
+      window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'display' && 'block' });
+      expect(document.querySelector('#computed-style')).toBeVisible();
     });
 
     it('should detect elements whose computed styles are visibility: hidden', () => {
       window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'visibility' && 'hidden' });
       expect(document.querySelector('#computed-style')).toBeHidden();
+      window.getComputedStyle = () => ({ getPropertyValue: (style) => style == 'visibility' && 'visible' });
+      expect(document.querySelector('#computed-style')).toBeVisible();
     });
   });
 

--- a/projects/spectator/src/lib/matchers.ts
+++ b/projects/spectator/src/lib/matchers.ts
@@ -410,11 +410,12 @@ export const toBePartial = comparator((actual, expected) => {
 
 /**
  * Hidden elements are elements that have:
- * 1. Display property set to "none"
- * 2. Width and height set to 0 (check not applied in jest)
- * 3. A hidden parent element (this also hides child elements)
- * 4. Type equal to "hidden" (only for form elements)
- * 5. A "hidden" attribute
+ * 1. Display or visibility style properties set to "none" or "hidden"
+ * 2. Display or visibility computed styles set to "none" or "hidden"
+ * 3. Width and height set to 0 (check not applied in jest)
+ * 4. A hidden parent element (this also hides child elements)
+ * 5. Type equal to "hidden" (only for form elements)
+ * 6. A "hidden" attribute
  */
 function isHidden(elOrSelector: HTMLElement | string): boolean {
   let el = $(elOrSelector)[0];
@@ -425,8 +426,8 @@ function isHidden(elOrSelector: HTMLElement | string): boolean {
 
   const hiddenWhen = [
     (el) => !(el.offsetWidth || el.offsetHeight || el.getClientRects().length),
-    (el) => el.style.display === 'none',
-    (el) => el.style.visibility === 'hidden',
+    (el) => el.style.display === 'none' || window.getComputedStyle(el).getPropertyValue?.('display') === 'none',
+    (el) => el.style.visibility === 'hidden' || window.getComputedStyle(el).getPropertyValue?.('visibility') === 'hidden',
     (el) => el.type === 'hidden',
     (el) => el.hasAttribute('hidden'),
   ];
@@ -454,11 +455,12 @@ function isHidden(elOrSelector: HTMLElement | string): boolean {
 
 /**
  * Hidden elements are elements that have:
- * 1. Display property set to "none"
- * 2. Width and height set to 0
- * 3. A hidden parent element (this also hides child elements)
- * 4. Type equal to "hidden" (only for form elements)
- * 5. A "hidden" attribute
+ * 1. Display or visibility style properties set to "none" or "hidden"
+ * 2. Display or visibility computed styles set to "none" or "hidden"
+ * 3. Width and height set to 0 (check not applied in jest)
+ * 4. A hidden parent element (this also hides child elements)
+ * 5. Type equal to "hidden" (only for form elements)
+ * 6. A "hidden" attribute
  *
  * expect('div').toBeHidden();
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, .toBeHidden cannot catch cases where an element is hidden through CSS, be it a separate style element, constructed stylesheets, or just CSS variables in the `style` attribute. This change should catch all of those cases.

Issue Number: N/A


## What is the new behavior?
Elements hidden with separate style element, constructed stylesheets, or CSS variables are now correctly determined to be hidden

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This test contains a breaking change in the sense that it can cause tests which were previously passing to fail and vice versa, but those affected tests are likely passing or failing in error. I'll leave that judgment about whether this warrants a major version bump to the maintainers of this library.

## Other information
