### PR TITLE
fix: 🐛 component-id collision error NG0912

### DIFF
--- a/projects/spectator/src/lib/spectator-host/host-component.ts
+++ b/projects/spectator/src/lib/spectator-host/host-component.ts
@@ -1,7 +1,8 @@
 import { Component, NgModule } from '@angular/core';
 
 @Component({
-  template: ''
+  selector: 'lib-ngneat-host-component',
+  template: '',
 })
 export class HostComponent {}
 
@@ -12,6 +13,6 @@ export class HostComponent {}
   Reference: https://github.com/angular/issues/13590
 */
 @NgModule({
-  declarations: [HostComponent]
+  declarations: [HostComponent],
 })
 export class HostModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Running tests with Spectator `15.0.1` inside the latest Nx (`16.6.0`) it is throwing this warning:
![image](https://github.com/ngneat/spectator/assets/260185/5adfef71-dff0-443c-82ba-f1fbaaed87b1)
```
NG0912: Component ID generation collision detected. Components '_HostComponent' and 'TestComponent'
with selector 'ng-component' generated the same component ID. To fix this, you can change the selector
of one of those components or add an extra host attribute to force a different ID.
Find more at https://angular.io/errors/NG0912
```

## What is the new behavior?

I removed the warning adding a selector to `HostComponent`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

```
Angular CLI: 16.1.6
Node: 18.16.1
Package Manager: npm 9.5.1
OS: linux x64

Angular: 16.1.7
... animations, common, compiler, compiler-cli, core, elements
... forms, language-service, platform-browser
... platform-browser-dynamic, router
```