### PR TITLE
doc(queries): add missing byRole example

### DIFF
--- a/docs/docs/queries.md
+++ b/docs/docs/queries.md
@@ -43,6 +43,7 @@ spectator.query(byLabel('By label'));
 spectator.query(byText('By text'));
 spectator.query(byText('By text', {selector: '#some .selector'}));
 spectator.query(byTextContent('By text content', {selector: '#some .selector'}));
+spectator.query(byRole('checkbox', { checked: true }));
 ```
 
 The difference between `byText` and `byTextContent` is that the former doesn't match text inside a nested elements.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
It is missing the `byRole` example from the [readme](https://github.com/ngneat/spectator?tab=readme-ov-file#dom-selector)

## What is the new behavior?
Add the `byRole` example

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
