### PR TITLE
fix: check DeferBlockBehavior is defined before settng default

### DIFF
--- a/projects/spectator/package.json
+++ b/projects/spectator/package.json
@@ -2,7 +2,7 @@
   "name": "@ngneat/spectator",
   "description": "A powerful tool to simplify your Angular tests",
   "author": "Netanel Basal <netanel7799s@gmail.com>",
-  "version": "17.1.0",
+  "version": "17.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/spectator/src/lib/base/options.ts
+++ b/projects/spectator/src/lib/base/options.ts
@@ -22,7 +22,7 @@ export interface BaseSpectatorOptions {
   overrideDirectives?: [Type<any>, MetadataOverride<Directive>][];
   overridePipes?: [Type<any>, MetadataOverride<Pipe>][];
   teardown?: ModuleTeardownOptions;
-  deferBlockBehavior?: DeferBlockBehavior;
+  deferBlockBehavior?: DeferBlockBehavior | undefined;
   errorOnUnknownElements?: boolean;
   errorOnUnknownProperties?: boolean;
 }
@@ -50,7 +50,7 @@ const defaultOptions: OptionalsRequired<BaseSpectatorOptions> = {
   teardown: { destroyAfterEach: false },
   errorOnUnknownElements: false,
   errorOnUnknownProperties: false,
-  deferBlockBehavior: DeferBlockBehavior.Playthrough,
+  deferBlockBehavior: DeferBlockBehavior?.Playthrough,
 };
 
 /**

--- a/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
+++ b/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
@@ -30,7 +30,7 @@ describe('StandalonePipe', () => {
       spectator = createPipe(`<div id="standalone">{{ thisField | standalone }}</div>`, { hostProps: { thisField: 'This' } });
     });
 
-    fit('should render and execute the StandalonePipe', () => {
+    it('should render and execute the StandalonePipe', () => {
       expect(spectator.element.querySelector('#standalone')).toContainText('This stands alone!');
     });
   });


### PR DESCRIPTION
DeferBlockBehavior is undefined on ng < 17

#644

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: N/A
#644 

## What is the new behavior?
undefined check added

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
master was not running all tests when I forked the repo as there a spec with "fit" in it. I removed this, ran all tests and fixed the breaking test that has nothing to do with my fix