### PR TITLE
fix: 🐛 component re-render when updating fields in lifecycle hook

### DIFF
--- a/projects/spectator/jest/test/ngonchanges-input/ngonchanges-input.component.spec.ts
+++ b/projects/spectator/jest/test/ngonchanges-input/ngonchanges-input.component.spec.ts
@@ -1,0 +1,25 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { NgOnChangesInputComponent } from '../../../test/ngonchanges-input/ngonchanges-input.component';
+
+describe('NgOnChangesInputComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<NgOnChangesInputComponent>;
+
+    const createComponent = createComponentFactory({
+      component: NgOnChangesInputComponent,
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should re-render when updating fields in ngOnChanges', () => {
+      expect(spectator.query('button')).toBeDisabled();
+      expect(spectator.query('button')).toHaveText('Button disabled');
+
+      spectator.setInput({ btnDisabled: false });
+      expect(spectator.query('button')).not.toBeDisabled();
+      expect(spectator.query('button')).toHaveText('Button enabled');
+    });
+  });
+});

--- a/projects/spectator/src/lib/spectator/spectator.ts
+++ b/projects/spectator/src/lib/spectator/spectator.ts
@@ -44,11 +44,11 @@ export class Spectator<C> extends DomSpectator<C> {
   public setInput<K extends keyof C>(input: K, inputValue: InferInputSignal<C[K]>): void;
   public setInput(input: any, value?: any): void {
     setProps(this.fixture.componentRef, input, value);
-    // Force cd on the tested component
-    this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
-
     // Force cd on the host component for cases such as: https://github.com/ngneat/spectator/issues/539
     this.detectChanges();
+
+    // Force cd on the tested component
+    this.debugElement.injector.get(ChangeDetectorRef).detectChanges();
   }
 
   public deferBlock(deferBlockIndex = 0): DeferBlocks {

--- a/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
+++ b/projects/spectator/test/matchers/matcher-enhancements.component.spec.ts
@@ -15,7 +15,7 @@ describe('Matcher enhancements', () => {
       const el = spectator.queryAll('.text-check');
       expect(el).toHaveText(['It should', 'different text', 'another']);
       expect(el).toContainText(['It should', 'different text', 'another']);
-      expect(el).toHaveExactText(['It should have', 'Some different text', ' And another one ']);
+      expect(el).toHaveExactText(['It should have', 'Some different text', 'And another one']);
       expect(el).toHaveExactText(['It should have', 'Some different text', 'And another one'], { trim: true });
       expect(el).toHaveExactTrimmedText(['It should have', 'Some different text', 'And another one']);
     });

--- a/projects/spectator/test/ngonchanges-input/ngonchanges-input.component.spec.ts
+++ b/projects/spectator/test/ngonchanges-input/ngonchanges-input.component.spec.ts
@@ -1,0 +1,25 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { NgOnChangesInputComponent } from './ngonchanges-input.component';
+
+describe('NgOnChangesInputComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<NgOnChangesInputComponent>;
+
+    const createComponent = createComponentFactory({
+      component: NgOnChangesInputComponent,
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should re-render when updating fields in ngOnChanges', () => {
+      expect(spectator.query('button')).toBeDisabled();
+      expect(spectator.query('button')).toHaveText('Button disabled');
+
+      spectator.setInput({ btnDisabled: false });
+      expect(spectator.query('button')).not.toBeDisabled();
+      expect(spectator.query('button')).toHaveText('Button enabled');
+    });
+  });
+});

--- a/projects/spectator/test/ngonchanges-input/ngonchanges-input.component.ts
+++ b/projects/spectator/test/ngonchanges-input/ngonchanges-input.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: `
+    <button [disabled]="btnDisabled">
+      {{ btnText }}
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NgOnChangesInputComponent {
+  @Input()
+  btnDisabled = true;
+
+  btnText = 'Button disabled';
+
+  ngOnChanges() {
+    this.btnText = this.btnDisabled ? 'Button disabled' : 'Button enabled';
+  }
+}

--- a/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
+++ b/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
@@ -30,7 +30,7 @@ describe('StandalonePipe', () => {
       spectator = createPipe(`<div id="standalone">{{ thisField | standalone }}</div>`, { hostProps: { thisField: 'This' } });
     });
 
-    fit('should render and execute the StandalonePipe', () => {
+    it('should render and execute the StandalonePipe', () => {
       expect(spectator.element.querySelector('#standalone')).toContainText('This stands alone!');
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See #643

When Spectator is used to set inputs on a component, the following will happen:
1. `ChangeDetectorRef.detectChanges()` is called
2. `fixture.detectChanges` is called

Issue Number: #643 

## What is the new behavior?

I simply swapped these 2 calls:

1. `fixture.detectChanges` will run a change detection cycle on the test fixture. This is when `ngOnChanges` will run
2. `ChangeDetectorRef.detectChanges()` will check the component view. This is where the change detection check will detect the updated field from `ngOnChanges` and re-render the component.

I wish I could give a better explanation to why this happens, but this is my interpretation of the bug/fix

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
