### PR TITLE
chore: 🏷️ Use generic return type for all jest matchers

### DIFF
--- a/projects/spectator/jest/src/lib/matchers-types.ts
+++ b/projects/spectator/jest/src/lib/matchers-types.ts
@@ -1,59 +1,59 @@
 declare namespace jest {
   interface Matchers<R> {
-    toExist(): boolean;
+    toExist(): R;
 
-    toHaveLength(expected: number): boolean;
+    toHaveLength(expected: number): R;
 
-    toHaveId(id: string | number): boolean;
+    toHaveId(id: string | number): R;
 
-    toHaveClass(className: string | string[], options?: { strict: boolean }): boolean;
+    toHaveClass(className: string | string[], options?: { strict: boolean }): R;
 
-    toHaveAttribute(attr: string | object, val?: string): boolean;
+    toHaveAttribute(attr: string | object, val?: string): R;
 
-    toHaveProperty(prop: string | object, val?: string | boolean): boolean;
+    toHaveProperty(prop: string | object, val?: string | boolean): R;
 
-    toContainProperty(prop: string | object, val?: string): boolean;
+    toContainProperty(prop: string | object, val?: string): R;
 
-    toHaveText(text: string | string[] | ((text: string) => boolean), exact?: boolean): boolean;
+    toHaveText(text: string | string[] | ((text: string) => boolean), exact?: boolean): R;
 
-    toContainText(text: string | string[] | ((text: string) => boolean), exact?: boolean): boolean;
+    toContainText(text: string | string[] | ((text: string) => boolean), exact?: boolean): R;
 
-    toHaveExactText(text: string | string[] | ((text: string) => boolean), options?: { trim: boolean }): boolean;
+    toHaveExactText(text: string | string[] | ((text: string) => boolean), options?: { trim: boolean }): R;
 
-    toHaveExactTrimmedText(text: string | string[] | ((text: string) => boolean)): boolean;
+    toHaveExactTrimmedText(text: string | string[] | ((text: string) => boolean)): R;
 
-    toHaveValue(value: string | string[]): boolean;
+    toHaveValue(value: string | string[]): R;
 
-    toContainValue(value: string | string[]): boolean;
+    toContainValue(value: string | string[]): R;
 
-    toHaveStyle(style: { [styleKey: string]: any }): boolean;
+    toHaveStyle(style: { [styleKey: string]: any }): R;
 
-    toHaveData({ data, val }: { data: string; val: string }): boolean;
+    toHaveData({ data, val }: { data: string; val: string }): R;
 
-    toBeChecked(): boolean;
+    toBeChecked(): R;
 
-    toBeIndeterminate(): boolean;
+    toBeIndeterminate(): R;
 
-    toBeDisabled(): boolean;
+    toBeDisabled(): R;
 
-    toBeEmpty(): boolean;
+    toBeEmpty(): R;
 
-    toBePartial(partial: object): boolean;
+    toBePartial(partial: object): R;
 
-    toBeHidden(): boolean;
+    toBeHidden(): R;
 
-    toBeSelected(): boolean;
+    toBeSelected(): R;
 
-    toBeVisible(): boolean;
+    toBeVisible(): R;
 
-    toBeFocused(): boolean;
+    toBeFocused(): R;
 
-    toBeMatchedBy(selector: string | Element): boolean;
+    toBeMatchedBy(selector: string | Element): R;
 
-    toHaveDescendant(selector: string | Element): boolean;
+    toHaveDescendant(selector: string | Element): R;
 
-    toHaveDescendantWithText({ selector, text }: { selector: string; text: string }): boolean;
+    toHaveDescendantWithText({ selector, text }: { selector: string; text: string }): R;
 
-    toHaveSelectedOptions(expected: string | string[] | HTMLOptionElement | HTMLOptionElement[]): boolean;
+    toHaveSelectedOptions(expected: string | string[] | HTMLOptionElement | HTMLOptionElement[]): R;
   }
 }


### PR DESCRIPTION
 This better aligns with jest documentation: https://archive.jestjs.io/docs/en/23.x/expect#expectextendmatchers and ensures that types can work properly with other jest extension libraries like jest-chain.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when another library is used that modifies the return type of a matcher, all custom matchers added by spectator cannot be overridden in TypeScript because they do not use the `R` generic. This fixes that problem.

Issue Number: N/A

## What is the new behavior?
All custom matchers now use the `R` generic instead of `boolean`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
