### PR TITLE
ci: 🎡 upgrade github actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ on:
       - master
 jobs:
   yarn-install:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - id: cache
         name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
@@ -22,14 +22,14 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [yarn-install]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
@@ -38,19 +38,19 @@ jobs:
         run: yarn build
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [yarn-install]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
- run on `ubuntu-latest`
- upgrade `github actions` to `v4`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Deprecation warning messages in github action builds:

> ⚠️ Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/cache@v2.


- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


Build with warnings: https://github.com/ngneat/spectator/actions/runs/9570842990

<img width="1144" alt="image" src="https://github.com/ngneat/spectator/assets/655241/b90ff0f0-0bbf-4c58-ad14-0d8ec8bf44d1">


## What is the new behavior?

✅ build with no warnings

https://github.com/chimurai/spectator/actions/runs/9572409980

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
