### PR TITLE
feat(spectator): support for Function-based outputs

### DIFF
--- a/projects/spectator/jest/test/function-output/function-output.component.spec.ts
+++ b/projects/spectator/jest/test/function-output/function-output.component.spec.ts
@@ -1,0 +1,47 @@
+import { createComponentFactory, createHostFactory, Spectator, SpectatorHost } from '@ngneat/spectator/jest';
+import { FunctionOutputComponent } from '../../../test/function-output/function-output.component';
+
+describe('FunctionOutputComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<FunctionOutputComponent>;
+
+    const createComponent = createComponentFactory({
+      component: FunctionOutputComponent,
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should emit the event on button click', () => {
+      let output;
+      spectator.output('buttonClick').subscribe((result) => (output = result));
+
+      spectator.click('button');
+
+      expect(output).toEqual(true);
+    });
+  });
+
+  describe('with SpectatorHost', () => {
+    let host: SpectatorHost<FunctionOutputComponent>;
+
+    const createHost = createHostFactory({
+      component: FunctionOutputComponent,
+      template: `<app-function-output/>`,
+    });
+
+    beforeEach(() => {
+      host = createHost();
+    });
+
+    it('should emit the event on button click', () => {
+      let output;
+      host.output('buttonClick').subscribe((result) => (output = result));
+
+      host.click('button');
+
+      expect(output).toEqual(true);
+    });
+  });
+});

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -1,4 +1,4 @@
-import { DebugElement, ElementRef, EventEmitter, Type } from '@angular/core';
+import { DebugElement, ElementRef, EventEmitter, OutputEmitterRef, Type } from '@angular/core';
 import { ComponentFixture, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Observable } from 'rxjs';
@@ -159,14 +159,16 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return null;
   }
 
-  public output<T, K extends keyof I = keyof I>(output: K): Observable<T> {
-    const observable = this.instance[output];
+  public output<K extends keyof I = keyof I>(output: K): I[K];
+  public output<T, K extends keyof I = keyof I>(output: K): Observable<T> | OutputEmitterRef<T>;
+  public output<T, K extends keyof I = keyof I>(output: K): I[K] | Observable<T> | OutputEmitterRef<T> {
+    const eventEmitter = this.instance[output];
 
-    if (!(observable instanceof Observable)) {
-      throw new Error(`${String(output)} is not an @Output`);
+    if (!(eventEmitter instanceof Observable) && !(eventEmitter instanceof OutputEmitterRef)) {
+      throw new Error(`${String(output)} is not an @Output or an output function`);
     }
 
-    return observable as Observable<T>;
+    return eventEmitter;
   }
 
   public tick(millis?: number): void {

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -18,8 +18,10 @@ import { BaseSpectator } from './base-spectator';
 
 const KEY_UP = 'keyup';
 
-type KeysMatchingOutput<T, V = EventEmitter<any> | OutputEmitterRef<any>> = keyof { [P in keyof T as T[P] extends V ? P : never]: P } &
-  keyof T;
+type KeysMatchingReturnType<T, V> = keyof { [P in keyof T as T[P] extends V ? P : never]: P } & keyof T;
+type KeysMatchingOutputFunction<T> = KeysMatchingReturnType<T, OutputEmitterRef<any>>;
+type KeysMatchingClassicOutput<T> = KeysMatchingReturnType<T, EventEmitter<any>>;
+type KeysMatchingOutput<T> = KeysMatchingOutputFunction<T> | KeysMatchingClassicOutput<T>;
 
 /**
  * @internal
@@ -163,7 +165,8 @@ export abstract class DomSpectator<I> extends BaseSpectator {
   }
 
   public output<K extends KeysMatchingOutput<I> = KeysMatchingOutput<I>>(output: K): I[K];
-  public output<T, K extends KeysMatchingOutput<I> = KeysMatchingOutput<I>>(output: K): Observable<T> | OutputEmitterRef<T>;
+  public output<T, K extends KeysMatchingClassicOutput<I> = KeysMatchingClassicOutput<I>>(output: K): Observable<T>;
+  public output<T, K extends KeysMatchingOutputFunction<I> = KeysMatchingOutputFunction<I>>(output: K): OutputEmitterRef<T>;
   public output<T, K extends KeysMatchingOutput<I>>(output: K): I[K] | Observable<T> | OutputEmitterRef<T> {
     const eventEmitter = this.instance[output];
 

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -18,6 +18,9 @@ import { BaseSpectator } from './base-spectator';
 
 const KEY_UP = 'keyup';
 
+type KeysMatchingOutput<T, V = EventEmitter<any> | OutputEmitterRef<any>> = keyof { [P in keyof T as T[P] extends V ? P : never]: P } &
+  keyof T;
+
 /**
  * @internal
  */
@@ -159,9 +162,9 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return null;
   }
 
-  public output<K extends keyof I = keyof I>(output: K): I[K];
-  public output<T, K extends keyof I = keyof I>(output: K): Observable<T> | OutputEmitterRef<T>;
-  public output<T, K extends keyof I = keyof I>(output: K): I[K] | Observable<T> | OutputEmitterRef<T> {
+  public output<K extends KeysMatchingOutput<I>>(output: K): I[K];
+  public output<T, K extends KeysMatchingOutput<I>>(output: K): Observable<T> | OutputEmitterRef<T>;
+  public output<T, K extends KeysMatchingOutput<I>>(output: K): I[K] | Observable<T> | OutputEmitterRef<T> {
     const eventEmitter = this.instance[output];
 
     if (!(eventEmitter instanceof Observable) && !(eventEmitter instanceof OutputEmitterRef)) {

--- a/projects/spectator/src/lib/base/dom-spectator.ts
+++ b/projects/spectator/src/lib/base/dom-spectator.ts
@@ -162,8 +162,8 @@ export abstract class DomSpectator<I> extends BaseSpectator {
     return null;
   }
 
-  public output<K extends KeysMatchingOutput<I>>(output: K): I[K];
-  public output<T, K extends KeysMatchingOutput<I>>(output: K): Observable<T> | OutputEmitterRef<T>;
+  public output<K extends KeysMatchingOutput<I> = KeysMatchingOutput<I>>(output: K): I[K];
+  public output<T, K extends KeysMatchingOutput<I> = KeysMatchingOutput<I>>(output: K): Observable<T> | OutputEmitterRef<T>;
   public output<T, K extends KeysMatchingOutput<I>>(output: K): I[K] | Observable<T> | OutputEmitterRef<T> {
     const eventEmitter = this.instance[output];
 

--- a/projects/spectator/test/function-output/function-output.component.spec.ts
+++ b/projects/spectator/test/function-output/function-output.component.spec.ts
@@ -1,0 +1,47 @@
+import { createComponentFactory, createHostFactory, Spectator, SpectatorHost } from '@ngneat/spectator';
+import { FunctionOutputComponent } from './function-output.component';
+
+describe('FunctionOutputComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<FunctionOutputComponent>;
+
+    const createComponent = createComponentFactory({
+      component: FunctionOutputComponent,
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should emit the event on button click', () => {
+      let output;
+      spectator.output('buttonClick').subscribe((result) => (output = result));
+
+      spectator.click('button');
+
+      expect(output).toEqual(true);
+    });
+  });
+
+  describe('with SpectatorHost', () => {
+    let host: SpectatorHost<FunctionOutputComponent>;
+
+    const createHost = createHostFactory({
+      component: FunctionOutputComponent,
+      template: `<app-function-output/>`,
+    });
+
+    beforeEach(() => {
+      host = createHost();
+    });
+
+    it('should emit the event on button click', () => {
+      let output;
+      host.output('buttonClick').subscribe((result) => (output = result));
+
+      host.click('button');
+
+      expect(output).toEqual(true);
+    });
+  });
+});

--- a/projects/spectator/test/function-output/function-output.component.ts
+++ b/projects/spectator/test/function-output/function-output.component.ts
@@ -1,0 +1,10 @@
+import { Component, input, output, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE } from '@angular/core';
+
+@Component({
+  selector: 'app-function-output',
+  template: ` <button (click)="buttonClick.emit(true)">Emit function output</button> `,
+  standalone: true,
+})
+export class FunctionOutputComponent {
+  public buttonClick = output<boolean>();
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
currently there are a couple of issues with `spectator.output`
1. Unless you add a specific return type then it returns an `Observable<unknown>` 
2. Doesn't support function based outputs (https://angular.dev/guide/components/output-fn#)

## What is the new behavior?

1. Added 2 additional overloads for the `output` method
-  one very similar to the existing one but with the return type `OutputEmitterRef<T>`
-  one that infers the return type based on the key name.
2. Limit the output names at compile time to field names that are of an output type

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```