### PR TITLE
feat(spectator): add support for runInInjectionContext()

### DIFF
--- a/projects/spectator/jest/src/lib/spectator-injection-context.ts
+++ b/projects/spectator/jest/src/lib/spectator-injection-context.ts
@@ -1,0 +1,30 @@
+import { AbstractType, InjectionToken, Type } from '@angular/core';
+import {
+  createInjectionContextFactory as baseInjectionContextFactory,
+  SpectatorInjectionContextOverrides,
+  SpectatorInjectionContextOptions,
+  SpectatorInjectionContext as BaseSpectatorInjectionContext,
+} from '@ngneat/spectator';
+import { mockProvider, SpyObject } from './mock';
+
+/**
+ * @publicApi
+ */
+export interface SpectatorInjectionContext extends BaseSpectatorInjectionContext {
+  inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>): SpyObject<T>;
+}
+
+/**
+ * @publicApi
+ */
+export type SpectatorInjectionContextFactory = (overrides?: SpectatorInjectionContextOverrides) => SpectatorInjectionContext;
+
+/**
+ * @publicApi
+ */
+export function createInjectionContextFactory(options: SpectatorInjectionContextOptions): SpectatorInjectionContextFactory {
+  return baseInjectionContextFactory({
+    mockProvider,
+    ...options,
+  }) as SpectatorInjectionContextFactory;
+}

--- a/projects/spectator/jest/src/public_api.ts
+++ b/projects/spectator/jest/src/public_api.ts
@@ -9,3 +9,4 @@ export * from './lib/spectator-service';
 export * from './lib/spectator-host';
 export * from './lib/spectator-routing';
 export * from './lib/spectator-pipe';
+export * from './lib/spectator-injection-context';

--- a/projects/spectator/jest/test/run-in-injection-context.spec.ts
+++ b/projects/spectator/jest/test/run-in-injection-context.spec.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable, InjectionToken, NgModule } from '@angular/core';
+import { createInjectionContextFactory, SpectatorInjectionContext } from '@ngneat/spectator/jest';
+
+const TEST_TOKEN = new InjectionToken<string>('simple-token');
+
+@Injectable()
+export class TestService {
+  flag = false;
+}
+
+@NgModule({
+  providers: [TestService],
+})
+export class TestModule {}
+
+const testFn = (arg: any) => {
+  const token = inject(TEST_TOKEN);
+  const { flag } = inject(TestService);
+
+  return { token, flag, arg };
+};
+
+describe('Run in injection context', () => {
+  describe('with Spectator', () => {
+    const createContext = createInjectionContextFactory({ imports: [TestModule], providers: [{ provide: TEST_TOKEN, useValue: 'abcd' }] });
+
+    let spectator: SpectatorInjectionContext;
+
+    beforeEach(() => (spectator = createContext()));
+
+    it('should execute fn in injection context', () => {
+      const service = spectator.inject(TestService);
+      service.flag = true;
+
+      const result = spectator.runInInjectionContext(() => testFn(2));
+      expect(result).toEqual({ token: 'abcd', flag: true, arg: 2 });
+    });
+  });
+});

--- a/projects/spectator/src/lib/base/base-spectator.ts
+++ b/projects/spectator/src/lib/base/base-spectator.ts
@@ -17,4 +17,8 @@ export abstract class BaseSpectator {
   public flushEffects(): void {
     TestBed.flushEffects();
   }
+
+  public runInInjectionContext<T>(fn: () => T): T {
+    return TestBed.runInInjectionContext(fn);
+  }
 }

--- a/projects/spectator/src/lib/spectator-injection-context/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-injection-context/create-factory.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { initialInjectionContextModule as initialInjectionContextModule } from './initial-module';
+import { getDefaultFunctionOptions, SpectatorInjectionContextOptions } from './options';
+import { overrideModules } from '../spectator/create-factory';
+import { BaseSpectatorOverrides } from '../base/options';
+import { SpectatorInjectionContext } from './spectator-injection-context';
+import { Provider } from '@angular/core';
+
+/**
+ * @publicApi
+ */
+export type SpectatorInjectionContextFactory = (overrides?: SpectatorInjectionContextOverrides) => SpectatorInjectionContext;
+
+/**
+ * @publicApi
+ */
+export interface SpectatorInjectionContextOverrides extends BaseSpectatorOverrides {}
+
+/**
+ * @publicApi
+ */
+export function createInjectionContextFactory(options: SpectatorInjectionContextOptions): SpectatorInjectionContextFactory {
+  const fullOptions = getDefaultFunctionOptions(options);
+
+  const moduleMetadata = initialInjectionContextModule(fullOptions);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule(moduleMetadata);
+    overrideModules(fullOptions);
+  });
+
+  return (overrides?: SpectatorInjectionContextOverrides) => {
+    const defaults: SpectatorInjectionContextOverrides = { providers: [] };
+    const { providers } = { ...defaults, ...overrides };
+
+    if (providers && providers.length) {
+      providers.forEach((provider: Provider) => {
+        TestBed.overrideProvider((provider as any).provide, provider as any);
+      });
+    }
+
+    return new SpectatorInjectionContext();
+  };
+}

--- a/projects/spectator/src/lib/spectator-injection-context/initial-module.ts
+++ b/projects/spectator/src/lib/spectator-injection-context/initial-module.ts
@@ -1,0 +1,11 @@
+import { initialModule, ModuleMetadata } from '../base/initial-module';
+import { FullInjectionContextOptions } from './options';
+
+/**
+ * @internal
+ */
+export function initialInjectionContextModule<F>(options: FullInjectionContextOptions): ModuleMetadata {
+  const moduleMetadata = initialModule(options);
+
+  return moduleMetadata;
+}

--- a/projects/spectator/src/lib/spectator-injection-context/options.ts
+++ b/projects/spectator/src/lib/spectator-injection-context/options.ts
@@ -1,0 +1,23 @@
+import { BaseSpectatorOptions, getDefaultBaseOptions } from '../base/options';
+import { merge } from '../internals/merge';
+import { AtLeastOneRequired, OptionalsRequired } from '../types';
+
+export type SpectatorInjectionContextOptions = AtLeastOneRequired<
+  Pick<BaseSpectatorOptions, 'imports' | 'mockProvider' | 'mocks' | 'providers'>
+>;
+
+const defaultFunctionOptions: OptionalsRequired<SpectatorInjectionContextOptions> = {
+  ...getDefaultBaseOptions(),
+};
+
+/**
+ * @internal
+ */
+export type FullInjectionContextOptions = Required<SpectatorInjectionContextOptions> & Required<BaseSpectatorOptions>;
+
+/**
+ * @internal
+ */
+export function getDefaultFunctionOptions(overrides: SpectatorInjectionContextOptions): FullInjectionContextOptions {
+  return merge(defaultFunctionOptions, overrides) as FullInjectionContextOptions;
+}

--- a/projects/spectator/src/lib/spectator-injection-context/spectator-injection-context.ts
+++ b/projects/spectator/src/lib/spectator-injection-context/spectator-injection-context.ts
@@ -1,0 +1,10 @@
+import { BaseSpectator } from '../base/base-spectator';
+
+/**
+ * @publicApi
+ */
+export class SpectatorInjectionContext extends BaseSpectator {
+  constructor() {
+    super();
+  }
+}

--- a/projects/spectator/src/lib/types.ts
+++ b/projects/spectator/src/lib/types.ts
@@ -15,6 +15,10 @@ export type InferInputSignals<C> = {
 
 export type OptionalsRequired<T> = Required<OptionalProperties<T>> & Partial<T>;
 
+export type AtLeastOneRequired<T> = {
+  [K in keyof T]: Required<Pick<T, K>> & Partial<Omit<T, K>>;
+}[keyof T];
+
 export type SpectatorElement = string | Element | DebugElement | ElementRef | Window | Document | DOMSelector;
 
 export type QueryType = Type<any> | DOMSelector | string;

--- a/projects/spectator/src/public_api.ts
+++ b/projects/spectator/src/public_api.ts
@@ -33,6 +33,15 @@ export { SpectatorPipeOptions } from './lib/spectator-pipe/options';
 export { createPipeFactory, SpectatorPipeFactory, SpectatorPipeOverrides } from './lib/spectator-pipe/create-factory';
 export { initialSpectatorPipeModule } from './lib/spectator-pipe/initial-module';
 
+export { SpectatorInjectionContext } from './lib/spectator-injection-context/spectator-injection-context';
+export { SpectatorInjectionContextOptions } from './lib/spectator-injection-context/options';
+export {
+  createInjectionContextFactory,
+  SpectatorInjectionContextFactory,
+  SpectatorInjectionContextOverrides,
+} from './lib/spectator-injection-context/create-factory';
+export { initialInjectionContextModule } from './lib/spectator-injection-context/initial-module';
+
 export * from './lib/dom-selectors';
 export * from './lib/matchers';
 export * from './lib/mock';

--- a/projects/spectator/test/run-in-injection-context.spec.ts
+++ b/projects/spectator/test/run-in-injection-context.spec.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable, InjectionToken, NgModule } from '@angular/core';
+import { createInjectionContextFactory, SpectatorInjectionContext } from '@ngneat/spectator';
+
+const TEST_TOKEN = new InjectionToken<string>('simple-token');
+
+@Injectable()
+export class TestService {
+  flag = false;
+}
+
+@NgModule({
+  providers: [TestService],
+})
+export class TestModule {}
+
+const testFn = (arg: any) => {
+  const token = inject(TEST_TOKEN);
+  const { flag } = inject(TestService);
+
+  return { token, flag, arg };
+};
+
+describe('Run in injection context', () => {
+  describe('with Spectator', () => {
+    const createContext = createInjectionContextFactory({ imports: [TestModule], providers: [{ provide: TEST_TOKEN, useValue: 'abcd' }] });
+
+    let spectator: SpectatorInjectionContext;
+
+    beforeEach(() => (spectator = createContext()));
+
+    it('should execute fn in injection context', () => {
+      const service = spectator.inject(TestService);
+      service.flag = true;
+
+      const result = spectator.runInInjectionContext(() => testFn(2));
+      expect(result).toEqual({ token: 'abcd', flag: true, arg: 2 });
+    });
+  });
+});

--- a/projects/spectator/vitest/src/lib/spectator-injection-context.ts
+++ b/projects/spectator/vitest/src/lib/spectator-injection-context.ts
@@ -1,0 +1,30 @@
+import { AbstractType, InjectionToken, Type } from '@angular/core';
+import {
+  createInjectionContextFactory as baseInjectionContextFactory,
+  SpectatorInjectionContextOverrides,
+  SpectatorInjectionContextOptions,
+  SpectatorInjectionContext as BaseSpectatorInjectionContext,
+} from '@ngneat/spectator';
+import { mockProvider, SpyObject } from './mock';
+
+/**
+ * @publicApi
+ */
+export interface SpectatorInjectionContext extends BaseSpectatorInjectionContext {
+  inject<T>(token: Type<T> | InjectionToken<T> | AbstractType<T>): SpyObject<T>;
+}
+
+/**
+ * @publicApi
+ */
+export type SpectatorInjectionContextFactory = (overrides?: SpectatorInjectionContextOverrides) => SpectatorInjectionContext;
+
+/**
+ * @publicApi
+ */
+export function createInjectionContextFactory(options: SpectatorInjectionContextOptions): SpectatorInjectionContextFactory {
+  return baseInjectionContextFactory({
+    mockProvider,
+    ...options,
+  }) as SpectatorInjectionContextFactory;
+}

--- a/projects/spectator/vitest/src/public_api.ts
+++ b/projects/spectator/vitest/src/public_api.ts
@@ -9,3 +9,4 @@ export * from './lib/spectator-service';
 export * from './lib/spectator-host';
 export * from './lib/spectator-routing';
 export * from './lib/spectator-pipe';
+export * from './lib/spectator-injection-context';

--- a/projects/spectator/vitest/test/run-in-injection-context.spec.ts
+++ b/projects/spectator/vitest/test/run-in-injection-context.spec.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable, InjectionToken, NgModule } from '@angular/core';
+import { createInjectionContextFactory, SpectatorInjectionContext } from '@ngneat/spectator/vitest';
+
+const TEST_TOKEN = new InjectionToken<string>('simple-token');
+
+@Injectable()
+export class TestService {
+  flag = false;
+}
+
+@NgModule({
+  providers: [TestService],
+})
+export class TestModule {}
+
+const testFn = (arg: any) => {
+  const token = inject(TEST_TOKEN);
+  const { flag } = inject(TestService);
+
+  return { token, flag, arg };
+};
+
+describe('Run in injection context', () => {
+  describe('with Spectator', () => {
+    const createContext = createInjectionContextFactory({ imports: [TestModule], providers: [{ provide: TEST_TOKEN, useValue: 'abcd' }] });
+
+    let spectator: SpectatorInjectionContext;
+
+    beforeEach(() => (spectator = createContext()));
+
+    it('should execute fn in injection context', () => {
+      const service = spectator.inject(TestService);
+      service.flag = true;
+
+      const result = spectator.runInInjectionContext(() => testFn(2));
+      expect(result).toEqual({ token: 'abcd', flag: true, arg: 2 });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #664 
There is no support for `runInInjectionContext()` in Spectator


## What is the new behavior?

- Each Spectator instance offers access to `runInInjectionContext()`
- New `createInjectionContextFactory` is included for easy DI Functions testing

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
