### PR TITLE
fix(spectator): setInput with object parameter for alias names (#691)

### DIFF
--- a/projects/spectator/jest/test/set-input-alias-names.spec.ts
+++ b/projects/spectator/jest/test/set-input-alias-names.spec.ts
@@ -33,6 +33,24 @@ describe('SetInputAliasNames', () => {
       expect(nameElement.innerHTML).toBe('John');
       expect(ageElement.innerHTML).toBe('123');
     });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent();
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
   });
 
   describe('signal inputs', () => {
@@ -63,6 +81,26 @@ describe('SetInputAliasNames', () => {
       // Act
       spectator.setInput('userName', 'John');
       spectator.setInput('age', '123');
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent({
+        detectChanges: false,
+      });
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
 
       // Assert
       expect(nameElement.innerHTML).toBe('John');

--- a/projects/spectator/src/lib/spectator/spectator.ts
+++ b/projects/spectator/src/lib/spectator/spectator.ts
@@ -41,6 +41,7 @@ export class Spectator<C> extends DomSpectator<C> {
   }
 
   public setInput<K extends keyof C>(input: InferInputSignals<C>): void;
+  public setInput(input: { [inputName: string]: unknown }): void;
   public setInput<K extends keyof C>(input: K, inputValue: InferInputSignal<C[K]>): void;
   public setInput(input: string, inputValue: unknown): void;
   public setInput(input: any, value?: any): void {

--- a/projects/spectator/test/set-input-alias-names.spec.ts
+++ b/projects/spectator/test/set-input-alias-names.spec.ts
@@ -33,6 +33,24 @@ describe('SetInputAliasNames', () => {
       expect(nameElement.innerHTML).toBe('John');
       expect(ageElement.innerHTML).toBe('123');
     });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent();
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
   });
 
   describe('signal inputs', () => {
@@ -63,6 +81,26 @@ describe('SetInputAliasNames', () => {
       // Act
       spectator.setInput('userName', 'John');
       spectator.setInput('age', '123');
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent({
+        detectChanges: false,
+      });
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
 
       // Assert
       expect(nameElement.innerHTML).toBe('John');

--- a/projects/spectator/vitest/test/set-input-alias-names.spec.ts
+++ b/projects/spectator/vitest/test/set-input-alias-names.spec.ts
@@ -33,6 +33,24 @@ describe('SetInputAliasNames', () => {
       expect(nameElement.innerHTML).toBe('John');
       expect(ageElement.innerHTML).toBe('123');
     });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent();
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
   });
 
   describe('signal inputs', () => {
@@ -63,6 +81,26 @@ describe('SetInputAliasNames', () => {
       // Act
       spectator.setInput('userName', 'John');
       spectator.setInput('age', '123');
+
+      // Assert
+      expect(nameElement.innerHTML).toBe('John');
+      expect(ageElement.innerHTML).toBe('123');
+    });
+
+    it('setInput with object should respect the alias names', () => {
+      // Arrange
+      const spectator = createComponent({
+        detectChanges: false,
+      });
+
+      const nameElement = spectator.query('[data-test="set-input--name"]')!;
+      const ageElement = spectator.query('[data-test="set-input--age"]')!;
+
+      // Act
+      spectator.setInput({
+        userName: 'John',
+        age: '123',
+      });
 
       // Assert
       expect(nameElement.innerHTML).toBe('John');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Cannot compile test when we call setInput on more than one input whose one is aliased (object parameter)

Issue Number: https://github.com/ngneat/spectator/issues/691


## What is the new behavior?

We can compile and execute test when we call setInput on more than one input whose one is aliased (object parameter)

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
