### PR TITLE
feat: add support for componentImports config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Become a bronze sponsor and get your logo on our README on GitHub.
 ## Table of Contents
 
 - [Features](#features)
+- [Sponsoring ngneat](#sponsoring-ngneat)
+  - [Gold Sponsors](#gold-sponsors)
+  - [Silver Sponsors](#silver-sponsors)
+  - [Bronze Sponsors](#bronze-sponsors)
 - [Table of Contents](#table-of-contents)
 - [Installation](#installation)
   - [NPM](#npm)
@@ -70,6 +74,7 @@ Become a bronze sponsor and get your logo on our README on GitHub.
     - [String Selector](#string-selector)
     - [Type Selector](#type-selector)
     - [DOM Selector](#dom-selector)
+  - [Parent Selector](#parent-selector)
     - [Testing Select Elements](#testing-select-elements)
     - [Mocking Components](#mocking-components)
     - [Testing Single Component/Directive Angular Modules](#testing-single-componentdirective-angular-modules)
@@ -88,8 +93,8 @@ Become a bronze sponsor and get your logo on our README on GitHub.
   - [Using Custom Host Component](#using-custom-host-component)
 - [Testing DI Functions](#testing-di-functions)
 - [Mocking Providers](#mocking-providers)
-  - [Mocking OnInit Dependencies](#mocking-oninit-dependencies)
-  - [Mocking Constructor Dependencies](#mocking-constructor-dependencies)
+  - [Mocking OnInit dependencies](#mocking-oninit-dependencies)
+  - [Mocking constructor dependencies](#mocking-constructor-dependencies)
 - [Jest Support](#jest-support)
 - [Vitest Support](#vitest-support)
 - [Testing with HTTP](#testing-with-http)
@@ -98,7 +103,7 @@ Become a bronze sponsor and get your logo on our README on GitHub.
 - [Custom Matchers](#custom-matchers)
 - [Schematics](#schematics)
 - [Default Schematics Collection](#default-schematics-collection)
-- [Working Spectator & Jest Sample Repo and Karma Comparison](#working-spectator--jest-sample-repo-and-karma-comparison)
+- [Working Spectator \& Jest Sample Repo and Karma Comparison](#working-spectator--jest-sample-repo-and-karma-comparison)
 - [Core Team](#core-team)
 - [Contributors](#contributors)
 
@@ -149,6 +154,7 @@ const createComponent = createComponentFactory({
   entryComponents: [],
   componentProviders: [], // Override the component's providers
   componentViewProviders: [], // Override the component's view providers
+  componentImports: [], // Override the component's imports in case of testing standalone component
   overrideModules: [], // Override modules
   overrideComponents: [], // Override components in case of testing standalone component
   overrideDirectives: [], // Override directives in case of testing standalone directive
@@ -223,6 +229,52 @@ it('should...', () => {
           remove: { imports: [StandaloneComponentWithDependency] },
           add: { imports: [MockStandaloneComponentWithDependency] },
         },
+      ],
+    ],
+  });
+
+  expect(host.query('#standalone')).toContainText('Standalone component with import!');
+  expect(host.query('#standaloneWithDependency')).toContainText('Standalone component with override dependency!');
+});
+```
+
+By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component.
+```ts
+@Component({
+  selector: `app-standalone-with-import`,
+  template: `<div id="standalone">Standalone component with import!</div>
+  <app-standalone-with-dependency></app-standalone-with-dependency>`,
+  imports: [StandaloneComponentWithDependency],
+  standalone: true,
+})
+export class StandaloneWithImportsComponent {}
+
+@Component({
+  selector: `app-standalone-with-dependency`,
+  template: `<div id="standaloneWithDependency">Standalone component with dependency!</div>`,
+  standalone: true,
+})
+export class StandaloneComponentWithDependency {
+  constructor(public query: QueryService) {}
+}
+
+@Component({
+  selector: `app-standalone-with-dependency`,
+  template: `<div id="standaloneWithDependency">Standalone component with override dependency!</div>`,
+  standalone: true,
+})
+export class MockStandaloneComponentWithDependency {
+  constructor() {}
+}
+
+it('should...', () => {
+  const spectator = createHostFactory({
+    component: StandaloneWithImportsComponent,
+    template: `<div><app-standalone-with-import></app-standalone-with-import></div>`,
+    componentImports: [
+      [
+        StandaloneComponentWithDependency,
+        MockStandaloneComponentWithDependency,
       ],
     ],
   });

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ it('should...', () => {
 });
 ```
 
-By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component.
+By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component. The `componentImports` property accepts an array of overrides. An override is an array of length 2, where the first entry is the original import to be removed from the tested component during the test and the second entry is the replacement import. In the example below, `StandaloneComponentWithDependency` is removed from the tested component, and `MockStandaloneComponentWithDependency` is added to the tested component imports.
 ```ts
 @Component({
   selector: `app-standalone-with-import`,

--- a/docs/docs/testing-components.md
+++ b/docs/docs/testing-components.md
@@ -122,7 +122,7 @@ it('should...', () => {
 
 ```
 
-By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component.
+By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component. The `componentImports` property accepts an array of overrides. An override is an array of length 2, where the first entry is the original import to be removed from the tested component during the test and the second entry is the replacement import. In the example below, `StandaloneComponentWithDependency` is removed from the tested component, and `MockStandaloneComponentWithDependency` is added to the tested component imports.
 ```ts
 @Component({
   selector: `app-standalone-with-import`,

--- a/docs/docs/testing-components.md
+++ b/docs/docs/testing-components.md
@@ -39,7 +39,9 @@ const createComponent = createComponentFactory({
   entryComponents: [],
   componentProviders: [], // Override the component's providers
   componentViewProviders: [], // Override the component's view providers
+  componentImports: [], // Override the component's imports in case of testing standalone component
   overrideModules: [], // Override modules
+  overrideComponents: [], // Override components in case of testing standalone 
   mocks: [], // Providers that will automatically be mocked
   componentMocks: [], // Component providers that will automatically be mocked
   componentViewProvidersMocks: [], // Component view providers that will be automatically mocked
@@ -110,6 +112,53 @@ it('should...', () => {
           remove: { imports: [StandaloneComponentWithDependency] },
           add: { imports: [MockStandaloneComponentWithDependency] },
         },
+      ],
+    ],
+  });
+
+  expect(host.query('#standalone')).toContainText('Standalone component with import!');
+  expect(host.query('#standaloneWithDependency')).toContainText('Standalone component with override dependency!');
+});
+
+```
+
+By passing `componentImports` config to our `createComponent()` function we can remove and override imports directly in the tested standalone component.
+```ts
+@Component({
+  selector: `app-standalone-with-import`,
+  template: `<div id="standalone">Standalone component with import!</div>
+  <app-standalone-with-dependency></app-standalone-with-dependency>`,
+  imports: [StandaloneComponentWithDependency],
+  standalone: true,
+})
+export class StandaloneWithImportsComponent {}
+
+@Component({
+  selector: `app-standalone-with-dependency`,
+  template: `<div id="standaloneWithDependency">Standalone component with dependency!</div>`,
+  standalone: true,
+})
+export class StandaloneComponentWithDependency {
+  constructor(public query: QueryService) {}
+}
+
+@Component({
+  selector: `app-standalone-with-dependency`,
+  template: `<div id="standaloneWithDependency">Standalone component with override dependency!</div>`,
+  standalone: true,
+})
+export class MockStandaloneComponentWithDependency {
+  constructor() {}
+}
+
+it('should...', () => {
+  const spectator = createHostFactory({
+    component: StandaloneWithImportsComponent,
+    template: `<div><app-standalone-with-import></app-standalone-with-import></div>`,
+    componentImports: [
+      [
+        StandaloneComponentWithDependency,
+        MockStandaloneComponentWithDependency,
       ],
     ],
   });

--- a/projects/spectator/src/lib/spectator-host/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-host/create-factory.ts
@@ -8,6 +8,7 @@ import { nodeByDirective } from '../internals/node-by-directive';
 import * as customMatchers from '../matchers';
 import {
   overrideComponentIfProviderOverridesSpecified,
+  overrideComponentImports,
   overrideComponents,
   overrideDirectives,
   overrideModules,
@@ -73,6 +74,8 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
     overridePipes(options);
 
     overrideComponentIfProviderOverridesSpecified(options);
+    overrideComponentImports(options);
+
     if (options.template) {
       TestBed.overrideComponent(options.host, {
         set: { template: options.template },

--- a/projects/spectator/src/lib/spectator/create-factory.ts
+++ b/projects/spectator/src/lib/spectator/create-factory.ts
@@ -1,5 +1,5 @@
-import { isStandalone, Provider, reflectComponentType, Type } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, isStandalone, Provider, reflectComponentType, Type } from '@angular/core';
+import { MetadataOverride, TestBed, waitForAsync } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { BaseSpectatorOptions, BaseSpectatorOverrides } from '../base/options';
@@ -48,6 +48,31 @@ export function overrideComponentIfProviderOverridesSpecified<C>(options: Requir
       set: providerConfiguration,
     });
   }
+}
+
+/**
+ * @internal
+ */
+export function overrideComponentImports<C>(options: Required<SpectatorOptions<C>>): void {
+  if (!options.componentImports.length) {
+    return;
+  }
+
+  TestBed.overrideComponent(
+    options.component,
+    options.componentImports.reduce<MetadataOverride<Component>>(
+      (r, [original, override]) => {
+        r.remove!.imports!.push(original);
+
+        if (override) {
+          r.add!.imports!.push(override);
+        }
+
+        return r;
+      },
+      { remove: { imports: [] }, add: { imports: [] } },
+    ),
+  );
 }
 
 /**
@@ -134,6 +159,7 @@ export function createComponentFactory<C>(typeOrOptions: Type<C> | SpectatorOpti
     overridePipes(options);
 
     overrideComponentIfProviderOverridesSpecified(options);
+    overrideComponentImports(options);
 
     TestBed.compileComponents();
   }));

--- a/projects/spectator/src/lib/spectator/options.ts
+++ b/projects/spectator/src/lib/spectator/options.ts
@@ -12,6 +12,7 @@ export interface SpectatorOptions<C> extends BaseSpectatorOptions {
   shallow?: boolean;
   componentProviders?: any[];
   componentViewProviders?: any[];
+  componentImports?: any[];
   detectChanges?: boolean;
   declareComponent?: boolean;
   componentMocks?: Type<any>[];
@@ -25,6 +26,7 @@ const defaultSpectatorOptions: OptionalsRequired<SpectatorOptions<any>> = {
   detectChanges: true,
   componentProviders: [],
   componentViewProviders: [],
+  componentImports: [],
   componentMocks: [],
   componentViewProvidersMocks: [],
 };

--- a/projects/spectator/test/standalone/component/standalone-with-imports.component.spec.ts
+++ b/projects/spectator/test/standalone/component/standalone-with-imports.component.spec.ts
@@ -1,0 +1,44 @@
+import { createComponentFactory, createHostFactory, Spectator, SpectatorHost } from '@ngneat/spectator';
+import { StandaloneComponent } from './standalone.component';
+import {
+  MockStandaloneChildComponent,
+  StandaloneChildComponent,
+  StandaloneWithImportsComponent,
+} from './standalone-with-imports.component';
+
+describe('StandaloneWithImportsComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<StandaloneWithImportsComponent>;
+
+    const createComponent = createComponentFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent with overridden import', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorHost', () => {
+    let host: SpectatorHost<StandaloneComponent>;
+
+    const createHost = createHostFactory({
+      component: StandaloneWithImportsComponent,
+      template: `<app-standalone-with-imports />`,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      host = createHost();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(host.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+});

--- a/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
+++ b/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
@@ -1,0 +1,28 @@
+import { Component, Injectable, inject } from '@angular/core';
+
+@Injectable()
+export class SomeService {}
+
+@Component({
+  selector: `app-standalone-child`,
+  template: `<div id="child-standalone">This stands alone child!</div>`,
+  standalone: true,
+})
+export class StandaloneChildComponent {
+  bla = inject(SomeService);
+}
+
+@Component({
+  selector: `app-standalone-child`,
+  template: `<div id="child-standalone">Mocked!</div>`,
+  standalone: true,
+})
+export class MockStandaloneChildComponent {}
+
+@Component({
+  selector: `app-standalone-with-imports`,
+  template: `<app-standalone-child />`,
+  standalone: true,
+  imports: [StandaloneChildComponent],
+})
+export class StandaloneWithImportsComponent {}

--- a/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
+++ b/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
@@ -1,16 +1,11 @@
-import { Component, Injectable, inject } from '@angular/core';
-
-@Injectable()
-export class SomeService {}
+import { Component } from '@angular/core';
 
 @Component({
   selector: `app-standalone-child`,
   template: `<div id="child-standalone">This stands alone child!</div>`,
   standalone: true,
 })
-export class StandaloneChildComponent {
-  bla = inject(SomeService);
-}
+export class StandaloneChildComponent {}
 
 @Component({
   selector: `app-standalone-child`,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
To override the tested component's imports, the 'overrideComponents' option can be used. This works but is not very intuitive and involves a relatively complex configuration.

Issue Number: N/A


## What is the new behavior?
Add 'componentImports' config option override the tested component's imports to allow for overrides of the tested component's imports. This config option is supported by createComponentFactory as well as createHostFactory.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change aims to improve the intuitiveness of testing standalone components as well as reduce boilerplate for the test setup.