### PR TITLE
test: set pool prop in vite config

### DIFF
--- a/projects/spectator/vite.config.mts
+++ b/projects/spectator/vite.config.mts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => ({
     environment: 'jsdom',
     include: ['vitest/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
+    pool: 'forks',
   },
   define: {
     'import.meta.vitest': mode !== 'production',

--- a/projects/spectator/vitest/test/highlight.directive.spec.ts
+++ b/projects/spectator/vitest/test/highlight.directive.spec.ts
@@ -3,6 +3,10 @@ import { createHostFactory } from '@ngneat/spectator/vitest';
 
 import { HighlightDirective } from '../../test/highlight.directive';
 
+import { JSDOM } from 'jsdom';
+const jsdom = new JSDOM();
+window = jsdom.window as any;
+
 describe('HighlightDirective', () => {
   let host: SpectatorHost<HighlightDirective>;
 

--- a/projects/spectator/vitest/test/zippy/zippy.component.spec.ts
+++ b/projects/spectator/vitest/test/zippy/zippy.component.spec.ts
@@ -6,6 +6,10 @@ import { SpectatorHost, createHostFactory } from '@ngneat/spectator/vitest';
 import { QueryService } from '../../../test/query.service';
 import { ZippyComponent } from '../../../test/zippy/zippy.component';
 
+import { JSDOM } from 'jsdom';
+const jsdom = new JSDOM();
+window = jsdom.window as any;
+
 describe('ZippyComponent', () => {
   let host: SpectatorHost<ZippyComponent>;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Running Vitest specs locally works fine; however, during ci, the specs fail with message "Segmentation fault"

Issue Number: N/A


## What is the new behavior?
Running all tests locally works.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Set `pool` config property to 'forks' in vite config as suggested here: https://github.com/vitest-dev/vitest/issues/3143. In addition, add definitions for window in tests that depend on window.