### PR TITLE
Allow Direct Usage of DOMSelector Instances in Custom Matchers

### DIFF
--- a/docs/docs/queries.md
+++ b/docs/docs/queries.md
@@ -56,6 +56,14 @@ For example, in this following HTML `byText('foobar', {selector: 'div'})` won't 
 </div>
 ```
 
+These DOM selectors are directly supported by our [Custom Matchers](./custom-matchers):
+
+```ts
+expect(byTextContent('By text content', {selector: '#some .selector'})).toExist();
+expect(byPlaceholder('Please enter your email address')).toHaveValue('my-value');
+// ... See the Custom Matchers section for a full list of possible matchers
+```
+
 ### Parent Selector
 Spectator allows you to query for nested elements within a parent element. This is useful when you have multiple instances of the same component on the page and you want to query for children within a specific one. The parent selector is a string selector that is used to find the parent element. The parent selector is passed as the second parameter to the query methods. For example:
 ```ts

--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -29,7 +29,7 @@ interface Dummy {
     <div role="article" aria-label="toHaveAttribute" data-id="my-data-id"></div>
     <input type="checkbox" role="article" aria-label="toHaveProperty" checked />
     <div role="article" aria-label="toHaveText">hello goodbye</div>
-    <div role="article" aria-label="toHaveExactText">hello goodbye</div>
+    <div role="article" aria-label="toHaveExactText">{{ ' ' }}hello goodbye</div>
     <div role="article" aria-label="toHaveExactTrimmedText">hello goodbye</div>
     <div role="article" aria-label="toContainText">hello goodbye</div>
     <input type="checkbox" role="article" aria-label="toHaveValue" value="value" />

--- a/projects/spectator/jest/test/matchers/matchers.spec.ts
+++ b/projects/spectator/jest/test/matchers/matchers.spec.ts
@@ -1,6 +1,6 @@
-import { toBeVisible, toBePartial } from '@ngneat/spectator';
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { byRole } from '@ngneat/spectator';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 
 interface Dummy {
   lorem: string;
@@ -20,6 +20,46 @@ interface Dummy {
     <div id="styles" style="background-color: indianred; color: chocolate; --primary: var(--black)"></div>
     <custom-element style="visibility: hidden"></custom-element>
     <div id="computed-style"></div>
+
+    <div role="article" aria-label="toExist"></div>
+    <div role="article" aria-label="toHaveLength"></div>
+    <div role="article" aria-label="toHaveLength"></div>
+    <div role="article" aria-label="toHaveId" id="my-id"></div>
+    <div role="article" aria-label="toHaveClass" class="my-class"></div>
+    <div role="article" aria-label="toHaveAttribute" data-id="my-data-id"></div>
+    <input type="checkbox" role="article" aria-label="toHaveProperty" checked />
+    <div role="article" aria-label="toHaveText">hello goodbye</div>
+    <div role="article" aria-label="toHaveExactText">hello goodbye</div>
+    <div role="article" aria-label="toHaveExactTrimmedText">hello goodbye</div>
+    <div role="article" aria-label="toContainText">hello goodbye</div>
+    <input type="checkbox" role="article" aria-label="toHaveValue" value="value" />
+    <input type="checkbox" role="article" aria-label="toContainValue" value="value" />
+    <div role="article" aria-label="toHaveStyle" style="background-color: indianred;"></div>
+    <div role="article" aria-label="toHaveData" data-the-data="my-data"></div>
+    <input type="checkbox" role="article" aria-label="toBeChecked" checked />
+    <input type="checkbox" role="article" aria-label="toBeIndeterminate" [indeterminate]="true" />
+    <input type="checkbox" role="article" aria-label="toBeDisabled" disabled />
+    <input type="text" role="article" aria-label="toBeEmpty" value="" />
+    <div role="article" aria-label="toBeHidden" style="display: none;"></div>
+    <select>
+      <option value="1" role="article" aria-label="toBeSelected" selected>1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </select>
+    <div role="article" aria-label="toBeVisible"></div>
+    <div role="article" aria-label="toBeMatchedBy"></div>
+    <div role="article" aria-label="toHaveDescendant">
+      <div class="descendant"></div>
+    </div>
+    <div role="article" aria-label="toHaveDescendantWithText">
+      <div class="descendant">with text</div>
+    </div>
+    <select multiple role="article" aria-label="toHaveSelectedOptions">
+      <option value="1" selected>1</option>
+      <option value="2" selected>2</option>
+      <option value="3">3</option>
+    </select>
+    <input type="text" role="article" aria-label="toBeFocused" />
   `,
   standalone: false,
 })
@@ -181,6 +221,44 @@ describe('Matchers', () => {
     it('should return false when expected style does not exist on element', () => {
       const element = spectator.query('#styles');
       expect(element).not.toHaveStyle({ height: '100px' });
+    });
+  });
+
+  describe('resolveDOMSelector', () => {
+    describe.each([
+      { matcher: 'toExist', args: [] },
+      { matcher: 'toHaveLength', args: [2] },
+      { matcher: 'toHaveId', args: ['my-id'] },
+      { matcher: 'toHaveClass', args: ['my-class'] },
+      { matcher: 'toHaveAttribute', args: ['data-id', 'my-data-id'] },
+      { matcher: 'toHaveProperty', args: ['checked', true] },
+      { matcher: 'toHaveText', args: ['hello'] },
+      { matcher: 'toHaveExactText', args: [' hello goodbye'] },
+      { matcher: 'toHaveExactTrimmedText', args: ['hello goodbye'] },
+      { matcher: 'toContainText', args: ['hello'] },
+      { matcher: 'toHaveValue', args: ['value'] },
+      { matcher: 'toContainValue', args: ['value'] },
+      { matcher: 'toHaveStyle', args: [{ backgroundColor: 'indianred' }] },
+      { matcher: 'toHaveData', args: [{ data: 'the-data', val: 'my-data' }] },
+      { matcher: 'toBeChecked', args: [] },
+      { matcher: 'toBeIndeterminate', args: [] },
+      { matcher: 'toBeDisabled', args: [] },
+      { matcher: 'toBeEmpty', args: [] },
+      { matcher: 'toBeHidden', args: [] },
+      { matcher: 'toBeSelected', args: [] },
+      { matcher: 'toBeVisible', args: [] },
+      { matcher: 'toBeMatchedBy', args: ['[aria-label="toBeMatchedBy"]'] },
+      { matcher: 'toHaveDescendant', args: ['.descendant'] },
+      { matcher: 'toHaveDescendantWithText', args: [{ selector: '.descendant', text: 'with text' }] },
+      { matcher: 'toHaveSelectedOptions', args: [['1', '2']] },
+      { matcher: 'toBeFocused', args: [], setup: (selector) => spectator.focus(selector) },
+    ])('$matcher', ({ matcher, args, setup }) => {
+      it('should allow string selectors, HTMLElements, and DOMSelectors', () => {
+        setup?.(`[aria-label="${matcher}"]`);
+        expect(`[aria-label="${matcher}"]`)[matcher](...args);
+        expect(spectator.queryAll(`[aria-label="${matcher}"]`))[matcher](...args);
+        expect(byRole('article', { name: matcher }))[matcher](...args);
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #541 

## What is the new behavior?

Adds direct support within the custom matchers to calculate DOM Selectors

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
