### PR TITLE
fix: remove `waitForAsync` (zoneless support)

### DIFF
--- a/projects/spectator/src/lib/spectator-directive/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-directive/create-factory.ts
@@ -1,5 +1,5 @@
 import { Provider, Type } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -62,14 +62,14 @@ export function createDirectiveFactory<D, H = HostComponent>(
 
   const moduleMetadata = initialSpectatorDirectiveModule<D, H>(options);
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
     overrideModules(options);
     overrideComponents(options);
     overrideDirectives(options);
     overridePipes(options);
-  }));
+  });
 
   return <HP>(template?: string, overrides?: SpectatorDirectiveOverrides<H, HP>) => {
     const defaults: SpectatorDirectiveOverrides<H, HP> = {

--- a/projects/spectator/src/lib/spectator-host/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-host/create-factory.ts
@@ -1,5 +1,5 @@
 import { Provider, Type } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -64,7 +64,7 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
 
   const moduleMetadata = initialSpectatorWithHostModule<C, H>(options);
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata).overrideModule(BrowserDynamicTestingModule, {});
 
@@ -81,7 +81,7 @@ export function createHostFactory<C, H = HostComponent>(typeOrOptions: Type<C> |
         set: { template: options.template },
       });
     }
-  }));
+  });
 
   return <HP>(template?: string, overrides?: SpectatorHostOverrides<H, HP>) => {
     const defaults: SpectatorHostOverrides<H, HP> = { hostProps: {} as any, detectChanges: true, providers: [] };

--- a/projects/spectator/src/lib/spectator-pipe/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-pipe/create-factory.ts
@@ -1,5 +1,5 @@
 import { Provider, Type } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { BaseSpectatorOverrides } from '../base/options';
@@ -40,12 +40,12 @@ export function createPipeFactory<P, H = HostComponent>(typeOrOptions: Type<P> |
 
   const moduleMetadata = initialSpectatorPipeModule<P, H>(options);
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
     overrideModules(options);
     overridePipes(options);
-  }));
+  });
 
   return <HP>(templateOrOverrides?: string | SpectatorPipeOverrides<H, HP>, overrides?: SpectatorPipeOverrides<H, HP>) => {
     const defaults: SpectatorPipeOverrides<H, HP> = {

--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -1,5 +1,5 @@
 import { NgZone, Provider, Type } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { addMatchers } from '../core';
@@ -42,7 +42,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
 
   const moduleMetadata = initialRoutingModule<C>(options);
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata);
 
@@ -52,9 +52,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
     overridePipes(options);
 
     overrideComponentIfProviderOverridesSpecified(options);
-
-    TestBed.compileComponents();
-  }));
+  });
 
   return (overrides?: SpectatorRoutingOverrides<C>) => {
     const defaults: SpectatorRoutingOverrides<C> = {

--- a/projects/spectator/src/lib/spectator/create-factory.ts
+++ b/projects/spectator/src/lib/spectator/create-factory.ts
@@ -1,5 +1,5 @@
 import { Component, isStandalone, Provider, reflectComponentType, Type } from '@angular/core';
-import { MetadataOverride, TestBed, waitForAsync } from '@angular/core/testing';
+import { MetadataOverride, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { BaseSpectatorOptions, BaseSpectatorOverrides } from '../base/options';
@@ -149,7 +149,7 @@ export function createComponentFactory<C>(typeOrOptions: Type<C> | SpectatorOpti
 
   const moduleMetadata = initialSpectatorModule<C>(options);
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     addMatchers(customMatchers);
     TestBed.configureTestingModule(moduleMetadata).overrideModule(BrowserDynamicTestingModule, {});
 
@@ -160,9 +160,7 @@ export function createComponentFactory<C>(typeOrOptions: Type<C> | SpectatorOpti
 
     overrideComponentIfProviderOverridesSpecified(options);
     overrideComponentImports(options);
-
-    TestBed.compileComponents();
-  }));
+  });
 
   return (overrides?: SpectatorOverrides<C>) => {
     const defaults: SpectatorOverrides<C> = { props: {}, detectChanges: true, providers: [] };


### PR DESCRIPTION
In this commit, we remove `waitForAsync` as it is no longer necessary. This rule has also been disabled internally at Google and is no longer in use. Its removal enables zoneless support, since `waitForAsync` depends on zone.js.

We also remove `compileComponents()`, as it is only required when `setClassMetadataAsync` is called—typically representing AOT pre-compiled components outside of TestBed.