### PR TITLE
fix: setHostInput should work the same across all types

### DIFF
--- a/projects/spectator/jest/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/jest/test/auto-focus.directive.spec.ts
@@ -80,3 +80,38 @@ describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
     expect(host.element).toHaveValue('foo');
   });
 });
+
+describe('DatoAutoFocusDirective (createDirectiveFactory)', () => {
+  let host: SpectatorDirective<AutoFocusDirective>;
+
+  const createHost = createDirectiveFactory({
+    directive: AutoFocusDirective,
+  });
+
+  it('should be focused', () => {
+    host = createHost(`<input datoAutoFocus="true">`);
+    const instance1 = host.query(AutoFocusDirective);
+    const instance2 = host.directive;
+    expect(instance1).toBe(instance2);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should NOT be focused', () => {
+    host = createHost(`<input [datoAutoFocus]="false">`);
+    expect(host.element).not.toBeFocused();
+  });
+
+  it('should work with dynamic input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
+    expect(host.element).not.toBeFocused();
+    host.setHostInput('isFocused', true);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should be able to type in input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
+
+    host.typeInElement('foo');
+    expect(host.element).toHaveValue('foo');
+  });
+});

--- a/projects/spectator/jest/test/standalone/pipe/standalone.pipe.spec.ts
+++ b/projects/spectator/jest/test/standalone/pipe/standalone.pipe.spec.ts
@@ -33,5 +33,15 @@ describe('StandalonePipe', () => {
     it('should render and execute the StandalonePipe', () => {
       expect(spectator.element.querySelector('#standalone')).toContainText('This stands alone!');
     });
+
+    it('should allow updating host input by key', () => {
+      spectator.setHostInput('thisField', 'That');
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
+
+    it('should allow updating host input by object', () => {
+      spectator.setHostInput({ thisField: 'That' });
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
   });
 });

--- a/projects/spectator/src/lib/spectator-directive/spectator-directive.ts
+++ b/projects/spectator/src/lib/spectator-directive/spectator-directive.ts
@@ -33,8 +33,8 @@ export class SpectatorDirective<D, H = HostComponent> extends DomSpectator<D> {
     return super.inject(token);
   }
 
-  public setHostInput<K extends keyof H>(input: Partial<H>): void;
-  public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
+  public setHostInput<K extends keyof H>(input: H extends HostComponent ? any : Partial<H>): void;
+  public setHostInput<K extends keyof H>(input: H extends HostComponent ? any : K, inputValue: H extends HostComponent ? any : H[K]): void;
   public setHostInput(input: any, value?: any): void {
     setHostProps(this.fixture.componentRef, input, value);
     this.detectChanges();

--- a/projects/spectator/src/lib/spectator-pipe/spectator-pipe.ts
+++ b/projects/spectator/src/lib/spectator-pipe/spectator-pipe.ts
@@ -22,8 +22,8 @@ export class SpectatorPipe<P, H = HostComponent> extends BaseSpectator {
     this.fixture.detectChanges();
   }
 
-  public setHostInput<K extends keyof H>(input: Partial<H>): void;
-  public setHostInput<K extends keyof H>(input: K, inputValue: H[K]): void;
+  public setHostInput<K extends keyof H>(input: H extends HostComponent ? any : Partial<H>): void;
+  public setHostInput<K extends keyof H>(input: H extends HostComponent ? any : K, inputValue: H extends HostComponent ? any : H[K]): void;
   public setHostInput(input: any, value?: any): void {
     setHostProps(this.fixture.componentRef, input, value);
     this.detectChanges();

--- a/projects/spectator/test/auto-focus/auto-focus.directive.spec.ts
+++ b/projects/spectator/test/auto-focus/auto-focus.directive.spec.ts
@@ -81,3 +81,38 @@ describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
     expect(host.element).toHaveValue('foo');
   });
 });
+
+describe('DatoAutoFocusDirective (createDirectiveFactory)', () => {
+  let host: SpectatorDirective<AutoFocusDirective>;
+
+  const createHost = createDirectiveFactory({
+    directive: AutoFocusDirective,
+  });
+
+  it('should be focused', () => {
+    host = createHost(`<input datoAutoFocus="true">`);
+    const instance1 = host.query(AutoFocusDirective);
+    const instance2 = host.directive;
+    expect(instance1).toBe(instance2);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should NOT be focused', () => {
+    host = createHost(`<input [datoAutoFocus]="false">`);
+    expect(host.element).not.toBeFocused();
+  });
+
+  it('should work with dynamic input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
+    expect(host.element).not.toBeFocused();
+    host.setHostInput('isFocused', true);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should be able to type in input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
+
+    host.typeInElement('foo');
+    expect(host.element).toHaveValue('foo');
+  });
+});

--- a/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
+++ b/projects/spectator/test/standalone/pipe/standalone.pipe.spec.ts
@@ -33,5 +33,15 @@ describe('StandalonePipe', () => {
     it('should render and execute the StandalonePipe', () => {
       expect(spectator.element.querySelector('#standalone')).toContainText('This stands alone!');
     });
+
+    it('should allow updating host input by key', () => {
+      spectator.setHostInput('thisField', 'That');
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
+
+    it('should allow updating host input by object', () => {
+      spectator.setHostInput({ thisField: 'That' });
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
   });
 });

--- a/projects/spectator/vitest/test/auto-focus.directive.spec.ts
+++ b/projects/spectator/vitest/test/auto-focus.directive.spec.ts
@@ -45,6 +45,7 @@ describe('DatoAutoFocusDirective', () => {
     expect(host.element).toHaveValue('foo');
   });
 });
+
 describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
   let host: SpectatorDirective<AutoFocusDirective, CustomHostComponent>;
 
@@ -75,6 +76,41 @@ describe('DatoAutoFocusDirective (createHostDirectiveFactory)', () => {
 
   it('should be able to type in input', () => {
     host = createHost(`<input [datoAutoFocus]="isFocused">`);
+
+    host.typeInElement('foo');
+    expect(host.element).toHaveValue('foo');
+  });
+});
+
+describe('DatoAutoFocusDirective (createDirectiveFactory)', () => {
+  let host: SpectatorDirective<AutoFocusDirective>;
+
+  const createHost = createDirectiveFactory({
+    directive: AutoFocusDirective,
+  });
+
+  it('should be focused', () => {
+    host = createHost(`<input datoAutoFocus="true">`);
+    const instance1 = host.query(AutoFocusDirective);
+    const instance2 = host.directive;
+    expect(instance1).toBe(instance2);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should NOT be focused', () => {
+    host = createHost(`<input [datoAutoFocus]="false">`);
+    expect(host.element).not.toBeFocused();
+  });
+
+  it('should work with dynamic input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
+    expect(host.element).not.toBeFocused();
+    host.setHostInput('isFocused', true);
+    expect(host.element).toBeFocused();
+  });
+
+  it('should be able to type in input', () => {
+    host = createHost(`<input [datoAutoFocus]="isFocused">`, { hostProps: { isFocused: false } });
 
     host.typeInElement('foo');
     expect(host.element).toHaveValue('foo');

--- a/projects/spectator/vitest/test/standalone/pipe/standalone.pipe.spec.ts
+++ b/projects/spectator/vitest/test/standalone/pipe/standalone.pipe.spec.ts
@@ -33,5 +33,15 @@ describe('StandalonePipe', () => {
     it('should render and execute the StandalonePipe', () => {
       expect(spectator.element.querySelector('#standalone')).toContainText('This stands alone!');
     });
+
+    it('should allow updating host input by key', () => {
+      spectator.setHostInput('thisField', 'That');
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
+
+    it('should allow updating host input by object', () => {
+      spectator.setHostInput({ thisField: 'That' });
+      expect(spectator.element.querySelector('#standalone')).toContainText('That stands alone!');
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using setHostInput with a SpectatorHost allows setting a new value by key e.g. `spectator.setHostInput('key': 'value');`
That behaviour is not aligned with the other types such as SpectatorPipe and SpectatorDirective.

Issue Number: N/A


## What is the new behavior?
setHostInput now works the same across all types.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Looking at the following commit https://github.com/ngneat/spectator/commit/3f63c68440f2dc11cb251e49d8ebdc8a9a44a5e9#diff-2faeed29080eef6a143b30148979bb5b8c31682e8eae5fc32341670183a18803
you can see that the new typing had been added to the spectator-host.ts file. I replicated that exact change to the pipe and directive as well. 