### PR TITLE
feat: add strong typings to function spies on SpyObject

### DIFF
--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -3,10 +3,12 @@ import { FactoryProvider, Type, AbstractType } from '@angular/core';
 
 type Writable<T> = { -readonly [P in keyof T]: T[P] };
 
+export declare type UnknownFunction = (...args: Array<unknown>) => unknown & Function;
+
 /**
  * @publicApi
  */
-export interface CompatibleSpy extends jasmine.Spy {
+export interface CompatibleSpy<F extends UnknownFunction = UnknownFunction> extends jasmine.Spy<(...args: Parameters<F>) => ReturnType<F>> {
   /**
    * By chaining the spy with and.returnValue, all calls to the function will return a specific
    * value.
@@ -17,7 +19,7 @@ export interface CompatibleSpy extends jasmine.Spy {
    * By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied
    * function.
    */
-  andCallFake(fn: Function): this;
+  andCallFake(fn: UnknownFunction): this;
 
   /**
    * removes all recorded calls
@@ -28,7 +30,7 @@ export interface CompatibleSpy extends jasmine.Spy {
 /**
  * @publicApi
  */
-export type SpyObject<T> = T & { [P in keyof T]: T[P] extends Function ? T[P] & CompatibleSpy : T[P] } & {
+export type SpyObject<T> = T & { [P in keyof T]: T[P] extends UnknownFunction ? T[P] & CompatibleSpy<T[P]> : T[P] } & {
   /**
    * Casts to type without readonly properties
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current version of the library, doesn't pass the argument/return information to the spy objects, so chained calls are reduced to `any` types.

```
spyProvider.methodToSpy.and.returnValue({})
```

The `methodToSpy` has a signature of `(parm: string) => boolean` but when chained like above, `returnValue` doesn't enforce type safety that the value is `boolean` because it's signature is `any`

## What is the new behavior?

Type safety is inferred from the Spied object's type, so `returnValue` now is typed to accept `boolean` instead of `any`

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[X] Maybe?
```
Technically, it's a breaking change in that consumers of the library may start getting compile errors where they haven't before. But if those fakes are correct for their tests, they should be the right types.

## Other information
