### PR TITLE
fix: fix void spy regressions, and properly type andCallFake

### DIFF
--- a/projects/spectator/src/lib/mock.ts
+++ b/projects/spectator/src/lib/mock.ts
@@ -3,7 +3,7 @@ import { FactoryProvider, Type, AbstractType } from '@angular/core';
 
 type Writable<T> = { -readonly [P in keyof T]: T[P] };
 
-declare type UnknownFunction = (...args: unknown[]) => unknown;
+declare type UnknownFunction = (...args: any[]) => any;
 
 /**
  * @publicApi
@@ -19,7 +19,7 @@ export interface CompatibleSpy<F extends UnknownFunction = UnknownFunction> exte
    * By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied
    * function.
    */
-  andCallFake(fn: UnknownFunction): this;
+  andCallFake(fn: F): this;
 
   /**
    * removes all recorded calls

--- a/projects/spectator/test/spy-object/person.ts
+++ b/projects/spectator/test/spy-object/person.ts
@@ -6,6 +6,18 @@ export class Person {
     return 'Hi!';
   }
 
+  public saySomething(something: string): string {
+    return `You said: ${something}`;
+  }
+
+  public voidMethod(): void {
+    // Do nothing
+  }
+
+  public voidMethodWithArguments(arg1: string, arg2: number): void {
+    // Do nothing
+  }
+
   public get age(): number {
     return 2019 - this.birthYear;
   }

--- a/projects/spectator/test/spy-object/spy-object.spec.ts
+++ b/projects/spectator/test/spy-object/spy-object.spec.ts
@@ -6,7 +6,23 @@ describe('SpyObject', () => {
   it('should mock all public methods', () => {
     const person = createSpyObject(Person);
 
+    // Check methods without arguments but returns
     person.sayHi.andReturn('Bye!');
+
+    // Check methods with arguments
+    person.saySomething.andReturn('');
+    person.saySomething.withArgs('Testing').and.returnValue('You said: Testing');
+    person.saySomething.andCallFake((something: string) => {
+      return `You said: ${something}`;
+    });
+
+    // Check pure void methods
+    person.voidMethod.andCallFake(() => {});
+
+    // Check void methods with arguments
+    person.voidMethodWithArguments.andCallFake((arg1: string, arg2: number) => {
+      // Do nothing
+    });
   });
 
   it('should enable spying on properties', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
#707 and #708 broke certain signatures of methods and are no longer detected as spies.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

## Other information
