### PR TITLE
feat: 🎸 add SpectatorRouting componentImports

### DIFF
--- a/projects/spectator/jest/test/standalone/component/standalone-with-imports.component.spec.ts
+++ b/projects/spectator/jest/test/standalone/component/standalone-with-imports.component.spec.ts
@@ -1,0 +1,68 @@
+import {
+  createComponentFactory,
+  createHostFactory,
+  createRoutingFactory,
+  Spectator,
+  SpectatorHost,
+  SpectatorRouting,
+} from '@ngneat/spectator/jest';
+import { StandaloneComponent } from '../../../../test/standalone/component/standalone.component';
+import {
+  MockStandaloneChildComponent,
+  StandaloneChildComponent,
+  StandaloneWithImportsComponent,
+} from '../../../../test/standalone/component/standalone-with-imports.component';
+
+describe('StandaloneWithImportsComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<StandaloneWithImportsComponent>;
+
+    const createComponent = createComponentFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent with overridden import', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorHost', () => {
+    let host: SpectatorHost<StandaloneComponent>;
+
+    const createHost = createHostFactory({
+      component: StandaloneWithImportsComponent,
+      template: `<app-standalone-with-imports />`,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      host = createHost();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(host.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    let spectator: SpectatorRouting<StandaloneWithImportsComponent>;
+
+    const createComponent = createRoutingFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+});

--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -7,6 +7,7 @@ import { setProps } from '../internals/query';
 import * as customMatchers from '../matchers';
 import {
   overrideComponentIfProviderOverridesSpecified,
+  overrideComponentImports,
   overrideComponents,
   overrideDirectives,
   overrideModules,
@@ -52,6 +53,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
     overridePipes(options);
 
     overrideComponentIfProviderOverridesSpecified(options);
+    overrideComponentImports(options);
   });
 
   return (overrides?: SpectatorRoutingOverrides<C>) => {

--- a/projects/spectator/test/standalone/component/standalone-with-imports.component.spec.ts
+++ b/projects/spectator/test/standalone/component/standalone-with-imports.component.spec.ts
@@ -1,4 +1,11 @@
-import { createComponentFactory, createHostFactory, Spectator, SpectatorHost } from '@ngneat/spectator';
+import {
+  createComponentFactory,
+  createHostFactory,
+  createRoutingFactory,
+  Spectator,
+  SpectatorHost,
+  SpectatorRouting,
+} from '@ngneat/spectator';
 import { StandaloneComponent } from './standalone.component';
 import {
   MockStandaloneChildComponent,
@@ -39,6 +46,23 @@ describe('StandaloneWithImportsComponent', () => {
 
     it('should render a StandaloneComponent', () => {
       expect(host.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    let spectator: SpectatorRouting<StandaloneWithImportsComponent>;
+
+    const createComponent = createRoutingFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
     });
   });
 });

--- a/projects/spectator/vitest/test/standalone/component/standalone-with-imports.component.spec.ts
+++ b/projects/spectator/vitest/test/standalone/component/standalone-with-imports.component.spec.ts
@@ -1,0 +1,68 @@
+import {
+  createComponentFactory,
+  createHostFactory,
+  createRoutingFactory,
+  Spectator,
+  SpectatorHost,
+  SpectatorRouting,
+} from '@ngneat/spectator/vitest';
+import { StandaloneComponent } from '../../../../test/standalone/component/standalone.component';
+import {
+  MockStandaloneChildComponent,
+  StandaloneChildComponent,
+  StandaloneWithImportsComponent,
+} from '../../../../test/standalone/component/standalone-with-imports.component';
+
+describe('StandaloneWithImportsComponent', () => {
+  describe('with Spectator', () => {
+    let spectator: Spectator<StandaloneWithImportsComponent>;
+
+    const createComponent = createComponentFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent with overridden import', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorHost', () => {
+    let host: SpectatorHost<StandaloneComponent>;
+
+    const createHost = createHostFactory({
+      component: StandaloneWithImportsComponent,
+      template: `<app-standalone-with-imports />`,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      host = createHost();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(host.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    let spectator: SpectatorRouting<StandaloneWithImportsComponent>;
+
+    const createComponent = createRoutingFactory({
+      component: StandaloneWithImportsComponent,
+      componentImports: [[StandaloneChildComponent, MockStandaloneChildComponent]],
+    });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('should render a StandaloneComponent', () => {
+      expect(spectator.query('#child-standalone')).toContainText('Mocked!');
+    });
+  });
+});


### PR DESCRIPTION
- add missing `componentImports` support for `SpectatorRouting`
- add missing `componentImports` unit tests for `jest` and `vitest`

✅ Closes: #715

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`SpectatorRouting` does not have support for `componentImports`

Issue Number: #715


## What is the new behavior?

`SpectatorRouting` does have support for `componentImports`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


Original PR which added `componentImports`: https://github.com/ngneat/spectator/pull/699