### PR TITLE
chore: 🤖 fix clutter in test terminal output

### DIFF
--- a/projects/spectator/jest/test/defer-block.spec.ts
+++ b/projects/spectator/jest/test/defer-block.spec.ts
@@ -5,7 +5,7 @@ import { createComponentFactory } from '@ngneat/spectator/jest';
 describe('DeferBlock', () => {
   describe('Playthrough Behavior', () => {
     @Component({
-      selector: 'app-root',
+      selector: 'app-root:not(.NG0912-a)',
       template: `
         <button data-test="button--isVisible" (click)="isVisible = !isVisible">Toggle</button>
 
@@ -42,7 +42,7 @@ describe('DeferBlock', () => {
 
   describe('Manual Behavior', () => {
     @Component({
-      selector: 'app-root',
+      selector: 'app-root:not(.NG0912-b)',
       template: `
         @defer (on viewport) {
           <div>empty defer block</div>
@@ -110,7 +110,7 @@ describe('DeferBlock', () => {
 
   describe('Manual Behavior with nested states', () => {
     @Component({
-      selector: 'app-root',
+      selector: 'app-root:not(.NG0912-c)',
       template: `
         @defer (on viewport) {
           <div>complete state #1</div>

--- a/projects/spectator/setup-jest.ts
+++ b/projects/spectator/setup-jest.ts
@@ -6,3 +6,13 @@ defineGlobalsInjections({
   providers: [TranslateService],
   declarations: [TranslatePipe],
 });
+
+beforeEach(() => {
+  const mockIntersectionObserver = jest.fn<IntersectionObserver>();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null,
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+});

--- a/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
+++ b/projects/spectator/test/standalone/component/standalone-with-imports.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 export class StandaloneChildComponent {}
 
 @Component({
-  selector: `app-standalone-child`,
+  selector: `app-standalone-child:not(.NG0912)`,
   template: `<div id="child-standalone">Mocked!</div>`,
   standalone: true,
 })


### PR DESCRIPTION
fix terminal console warnings and errors when running tests:

- fix `jest` "ERROR ReferenceError: IntersectionObserver is not defined" 
  - Use same mock from `vitest`: https://github.com/ngneat/spectator/blob/691c476e7108eb556c47cab1f449b2f4687ebb23/projects/spectator/setup-vitest.ts#L17-L25
- fix NG0912: Component ID generation collision detected (https://angular.dev/errors/NG0912)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<img width="740" height="339" alt="image" src="https://github.com/user-attachments/assets/e5f350f4-c400-4146-b1ff-85d96a10f5c2" />

## What is the new behavior?

<img width="667" height="339" alt="image" src="https://github.com/user-attachments/assets/768d67e1-89fe-427d-b744-6a77dafd01a3" />


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
