### PR TITLE
docs: ✏️ byTestId DOM selector

### DIFF
--- a/docs/docs/queries.md
+++ b/docs/docs/queries.md
@@ -44,6 +44,7 @@ spectator.query(byText('By text'));
 spectator.query(byText('By text', {selector: '#some .selector'}));
 spectator.query(byTextContent('By text content', {selector: '#some .selector'}));
 spectator.query(byRole('checkbox', { checked: true }));
+spectator.query(byTestId('someTestId'))
 ```
 
 The difference between `byText` and `byTextContent` is that the former doesn't match text inside a nested elements.
@@ -62,6 +63,14 @@ These DOM selectors are directly supported by our [Custom Matchers](./custom-mat
 expect(byTextContent('By text content', {selector: '#some .selector'})).toExist();
 expect(byPlaceholder('Please enter your email address')).toHaveValue('my-value');
 // ... See the Custom Matchers section for a full list of possible matchers
+```
+
+Configure `@testing-library/dom` to use `byTestId` with a different `testIdAttribute`
+
+```ts
+import { configure } from '@testing-library/dom';
+
+configure({ testIdAttribute: 'data-test' });
 ```
 
 ### Parent Selector

--- a/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/jest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -8,7 +8,9 @@ import {
   byTitle,
   byValue,
   byTextContent,
+  byTestId,
 } from '@ngneat/spectator/jest';
+import { configure, getConfig } from '@testing-library/dom';
 
 import { DomSelectorsComponent, DomSelectorsNestedComponent } from '../../../test/dom-selectors/dom-selectors.component';
 
@@ -168,6 +170,25 @@ describe('DomSelectorsComponent', () => {
         const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
         expect(element).toHaveId('text-content-span-2');
       });
+    });
+  });
+
+  describe('byTestId', () => {
+    const { testIdAttribute } = getConfig();
+    beforeEach(() => configure({ testIdAttribute }));
+    afterEach(() => configure({ testIdAttribute }));
+
+    it('should allow querying with byTestId (default: data-testid)', () => {
+      const element = spectator.query(byTestId('by-testid-default'));
+      expect(element).toHaveAttribute('data-testid', 'by-testid-default');
+    });
+
+    it('should allow querying with byTestId and custom testIdAttribute', () => {
+      // configure byTestId to use the custom attribute
+      configure({ testIdAttribute: 'data-testid-custom' });
+
+      const element = spectator.query(byTestId('by-testid-custom'));
+      expect(element).toHaveAttribute('data-testid-custom', 'by-testid-custom');
     });
   });
 });

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.spec.ts
@@ -2,6 +2,7 @@ import {
   byAltText,
   byLabel,
   byPlaceholder,
+  byTestId,
   byText,
   byTextContent,
   byTitle,
@@ -10,6 +11,7 @@ import {
   createComponentFactory,
   Spectator,
 } from '@ngneat/spectator';
+import { configure, getConfig } from '@testing-library/dom';
 
 import { DomSelectorsComponent, DomSelectorsNestedComponent } from './dom-selectors.component';
 
@@ -214,6 +216,25 @@ describe('DomSelectorsComponent', () => {
     it('should allow querying by generic role with byRole matcher options ', () => {
       const element = spectator.query(byRole('checkbox', { checked: true }));
       expect(element).toHaveExactText('Sugar');
+    });
+  });
+
+  describe('byTestId', () => {
+    const { testIdAttribute } = getConfig();
+    beforeEach(() => configure({ testIdAttribute }));
+    afterEach(() => configure({ testIdAttribute }));
+
+    it('should allow querying with byTestId (default: data-testid)', () => {
+      const element = spectator.query(byTestId('by-testid-default'));
+      expect(element).toHaveAttribute('data-testid', 'by-testid-default');
+    });
+
+    it('should allow querying with byTestId and custom testIdAttribute', () => {
+      // configure byTestId to use the custom attribute
+      configure({ testIdAttribute: 'data-testid-custom' });
+
+      const element = spectator.query(byTestId('by-testid-custom'));
+      expect(element).toHaveAttribute('data-testid-custom', 'by-testid-custom');
     });
   });
 });

--- a/projects/spectator/test/dom-selectors/dom-selectors.component.ts
+++ b/projects/spectator/test/dom-selectors/dom-selectors.component.ts
@@ -52,6 +52,11 @@ export class DomSelectorsNestedComponent {}
       <app-dom-selectors-nested-components id="first"></app-dom-selectors-nested-components>
       <app-dom-selectors-nested-components id="last"></app-dom-selectors-nested-components>
     </div>
+
+    <div id="testid">
+      <div data-testid="by-testid-default"></div>
+      <div data-testid-custom="by-testid-custom"></div>
+    </div>
   `,
   standalone: false,
   imports: [DomSelectorsNestedComponent],

--- a/projects/spectator/vitest/test/dom-selectors/dom-selectors.component.spec.ts
+++ b/projects/spectator/vitest/test/dom-selectors/dom-selectors.component.spec.ts
@@ -8,7 +8,9 @@ import {
   byTitle,
   byValue,
   byTextContent,
+  byTestId,
 } from '@ngneat/spectator/vitest';
+import { configure, getConfig } from '@testing-library/dom';
 
 import { DomSelectorsComponent, DomSelectorsNestedComponent } from '../../../test/dom-selectors/dom-selectors.component';
 
@@ -168,6 +170,25 @@ describe('DomSelectorsComponent', () => {
         const element = spectator.query(byTextContent(matcher, { selector: '#text-content-root [id^="text-content-span"]' }));
         expect(element).toHaveId('text-content-span-2');
       });
+    });
+  });
+
+  describe('byTestId', () => {
+    const { testIdAttribute } = getConfig();
+    beforeEach(() => configure({ testIdAttribute }));
+    afterEach(() => configure({ testIdAttribute }));
+
+    it('should allow querying with byTestId (default: data-testid)', () => {
+      const element = spectator.query(byTestId('by-testid-default'));
+      expect(element).toHaveAttribute('data-testid', 'by-testid-default');
+    });
+
+    it('should allow querying with byTestId and custom testIdAttribute', () => {
+      // configure byTestId to use the custom attribute
+      configure({ testIdAttribute: 'data-testid-custom' });
+
+      const element = spectator.query(byTestId('by-testid-custom'));
+      expect(element).toHaveAttribute('data-testid-custom', 'by-testid-custom');
     });
   });
 });


### PR DESCRIPTION
✅ fixes: #380

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[x] Other... Please describe: Add missing `byTestId` unit tests
```

## What is the current behavior?

`byTestId` is not documented: https://ngneat.github.io/spectator/docs/queries#dom-selector

<img width="806" height="358" alt="Screenshot 2025-09-13 at 14 53 07" src="https://github.com/user-attachments/assets/0b10c6f8-1797-44b3-99e3-451517b6b61d" />


## What is the new behavior?

- Documented `byTestId`
- Document how to use `byTestId` with custom `testIdAttribute`
   (https://testing-library.com/docs/queries/bytestid#overriding-data-testid)
- Add missing `byTestId` unit tests
- Updated `byTestId` documentation for AI assisted coding: https://context7.com/ngneat/spectator

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

`byTestId` was added in https://github.com/ngneat/spectator/pull/32