### PR TITLE
feat: 🎸 support for bindings

### DIFF
--- a/docs/docs/testing-components.md
+++ b/docs/docs/testing-components.md
@@ -37,6 +37,7 @@ const createComponent = createComponentFactory({
   providers: [],
   declarations: [],
   entryComponents: [],
+  bindings: [], // Forward to Angular TestComponentOptions in TestBed.createComponent(ButtonComponent, { bindings})
   componentProviders: [], // Override the component's providers
   componentViewProviders: [], // Override the component's view providers
   componentImports: [], // Override the component's imports in case of testing standalone component
@@ -302,3 +303,43 @@ createComponentFactory({
 ```
 
 cf. https://angular.io/api/core/testing/TestBed#overrideModule
+
+## Angular TestComponentOptions: `bindings`
+
+Configure `bindings` to set TestComponentOptions in `TestBed.createComponent(ButtonComponent, { bindings })`.
+
+Use `bindings` to apply `Bindings` to the root component. An alternative to `createHostFactory`, avoiding the need to create a wrapper component.
+
+```ts
+@Component({
+  selector: 'my-component',
+  template: `
+    <h1>{{ title }}</h1>
+    <button (click)="onClick()">{{ value }}</button>
+  `,
+})
+export class MyComponent {
+  @Input() title = '';
+  @Output() clicked = new EventEmitter<void>();
+  @Input() value = 'initial';
+  @Output() valueChange = new EventEmitter<string>();
+
+  onClick() {
+    this.clicked.emit();
+  }
+}
+
+let clicks = 0;
+const value = signal('initial');
+
+const createComponent = createComponentFactory({
+  component: MyComponent,
+  bindings: [
+    inputBinding('title', signal('Hello')),
+    outputBinding('clicked', () => clicks++),
+    twoWayBinding('value', value),
+  ],
+});
+```
+
+cf. https://angular.dev/api/core/testing/TestComponentOptions

--- a/projects/spectator/jest/test/bindings/bindings.component.spec.ts
+++ b/projects/spectator/jest/test/bindings/bindings.component.spec.ts
@@ -1,0 +1,231 @@
+import { createComponentFactory, createRoutingFactory, Spectator, SpectatorRouting } from '@ngneat/spectator/jest';
+
+import { TestCompHost, TestCompInput, TestCompOutput, TestCompTwoWayBinding } from '../../../test/bindings/bindings.component';
+import { inputBinding, outputBinding, signal, twoWayBinding, WritableSignal } from '@angular/core';
+
+describe('Component Bindings', () => {
+  describe('with Spectator', () => {
+    describe('Input Bindings', () => {
+      let spectator: Spectator<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createComponentFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: Spectator<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createComponentFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: Spectator<TestCompTwoWayBinding>;
+      const value = signal('initial');
+      const createComponent = createComponentFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: Spectator<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createComponentFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    describe('Input Bindings', () => {
+      let spectator: SpectatorRouting<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createRoutingFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: SpectatorRouting<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createRoutingFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: SpectatorRouting<TestCompTwoWayBinding>;
+
+      const value = signal('initial');
+      const createComponent = createRoutingFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: SpectatorRouting<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createRoutingFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+});

--- a/projects/spectator/src/lib/spectator-routing/create-factory.ts
+++ b/projects/spectator/src/lib/spectator-routing/create-factory.ts
@@ -94,7 +94,7 @@ export function createRoutingFactory<C>(typeOrOptions: Type<C> | SpectatorRoutin
 }
 
 function createSpectatorRouting<C>(options: Required<SpectatorRoutingOptions<C>>, props?: InferInputSignals<C>): SpectatorRouting<C> {
-  const fixture = TestBed.createComponent(options.component);
+  const fixture = TestBed.createComponent(options.component, { bindings: options.bindings });
   const debugElement = fixture.debugElement;
 
   const component = setProps(fixture.componentRef, props);

--- a/projects/spectator/src/lib/spectator/create-factory.ts
+++ b/projects/spectator/src/lib/spectator/create-factory.ts
@@ -183,7 +183,7 @@ export function createComponentFactory<C>(typeOrOptions: Type<C> | SpectatorOpti
 }
 
 function createSpectator<C>(options: Required<SpectatorOptions<C>>, props?: InferInputSignals<C>): Spectator<C> {
-  const fixture = TestBed.createComponent(options.component);
+  const fixture = TestBed.createComponent(options.component, { bindings: options.bindings });
   const debugElement = fixture.debugElement;
 
   const component = setProps(fixture.componentRef, props);

--- a/projects/spectator/src/lib/spectator/options.ts
+++ b/projects/spectator/src/lib/spectator/options.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { Type, Binding } from '@angular/core';
 
 import { getDefaultBaseOptions, BaseSpectatorOptions } from '../base/options';
 import { merge } from '../internals/merge';
@@ -10,6 +10,8 @@ import { OptionalsRequired } from '../types';
 export interface SpectatorOptions<C> extends BaseSpectatorOptions {
   component: Type<C>;
   shallow?: boolean;
+  /** set options for TestBed.createComponent(component, options: TestComponentOptions)  */
+  bindings?: Binding[]; // TestComponentOptions['bindings'];
   componentProviders?: any[];
   componentViewProviders?: any[];
   componentImports?: any[];
@@ -29,6 +31,7 @@ const defaultSpectatorOptions: OptionalsRequired<SpectatorOptions<any>> = {
   componentImports: [],
   componentMocks: [],
   componentViewProvidersMocks: [],
+  bindings: [],
 };
 
 /**

--- a/projects/spectator/test/bindings/bindings.component.spec.ts
+++ b/projects/spectator/test/bindings/bindings.component.spec.ts
@@ -1,0 +1,231 @@
+import { createComponentFactory, Spectator, createRoutingFactory, SpectatorRouting } from '@ngneat/spectator';
+
+import { TestCompHost, TestCompInput, TestCompOutput, TestCompTwoWayBinding } from './bindings.component';
+import { inputBinding, outputBinding, signal, twoWayBinding, WritableSignal } from '@angular/core';
+
+describe('Component Bindings', () => {
+  describe('with Spectator', () => {
+    describe('Input Bindings', () => {
+      let spectator: Spectator<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createComponentFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: Spectator<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createComponentFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: Spectator<TestCompTwoWayBinding>;
+      const value = signal('initial');
+      const createComponent = createComponentFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: Spectator<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createComponentFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    describe('Input Bindings', () => {
+      let spectator: SpectatorRouting<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createRoutingFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: SpectatorRouting<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createRoutingFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: SpectatorRouting<TestCompTwoWayBinding>;
+
+      const value = signal('initial');
+      const createComponent = createRoutingFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: SpectatorRouting<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createRoutingFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+});

--- a/projects/spectator/test/bindings/bindings.component.ts
+++ b/projects/spectator/test/bindings/bindings.component.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, input, Output } from '@angular/core';
+
+@Component({ template: '' })
+export class TestCompInput {
+  @Input() value = 0;
+}
+
+@Component({ template: '<button (click)="event.emit()">Click me</button>' })
+export class TestCompOutput {
+  @Output() event = new EventEmitter<void>();
+}
+
+@Component({ template: 'Value: {{value}}' })
+export class TestCompTwoWayBinding {
+  @Input() value = '';
+  @Output() valueChange = new EventEmitter<string>();
+}
+
+@Component({
+  selector: 'my-host-comp',
+  template: '...',
+  host: { '[class.checked]': 'isChecked()' },
+})
+export class TestCompHost {
+  isChecked = input(false);
+}

--- a/projects/spectator/vitest/test/bindings/bindings.component.spec.ts
+++ b/projects/spectator/vitest/test/bindings/bindings.component.spec.ts
@@ -1,0 +1,231 @@
+import { createComponentFactory, createRoutingFactory, Spectator, SpectatorRouting } from '@ngneat/spectator/vitest';
+
+import { TestCompHost, TestCompInput, TestCompOutput, TestCompTwoWayBinding } from '../../../test/bindings/bindings.component';
+import { inputBinding, outputBinding, signal, twoWayBinding, WritableSignal } from '@angular/core';
+
+describe('Component Bindings', () => {
+  describe('with Spectator', () => {
+    describe('Input Bindings', () => {
+      let spectator: Spectator<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createComponentFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: Spectator<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createComponentFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: Spectator<TestCompTwoWayBinding>;
+      const value = signal('initial');
+      const createComponent = createComponentFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: Spectator<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createComponentFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+
+  describe('with SpectatorRouting', () => {
+    describe('Input Bindings', () => {
+      let spectator: SpectatorRouting<TestCompInput>;
+      const value = signal(1);
+
+      const createComponent = createRoutingFactory({
+        component: TestCompInput,
+        bindings: [inputBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to inputs', () => {
+        // Assert - Initial state
+        expect(spectator.component.value).toBe(1);
+
+        // Act
+        value.set(2);
+        spectator.fixture.detectChanges();
+
+        // Assert - After change
+        expect(spectator.component.value).toBe(2);
+      });
+    });
+
+    describe('Output Bindings', () => {
+      let spectator: SpectatorRouting<TestCompOutput>;
+      let count = 0;
+
+      const createComponent = createRoutingFactory({
+        component: TestCompOutput,
+        bindings: [outputBinding('event', () => count++)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind to outputs', () => {
+        // Assert - Initial state
+        expect(count).toBe(0);
+
+        // Act
+        spectator.click('button');
+
+        // Assert - After click
+        expect(count).toBe(1);
+      });
+    });
+
+    describe('Two-Way Bindings', () => {
+      let spectator: SpectatorRouting<TestCompTwoWayBinding>;
+
+      const value = signal('initial');
+      const createComponent = createRoutingFactory({
+        component: TestCompTwoWayBinding,
+        bindings: [twoWayBinding('value', value)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should be able to bind two-way bindings', () => {
+        // Assert - Initial state
+        expect(value()).toBe('initial');
+        expect(spectator.element.textContent).toBe('Value: initial');
+
+        // Act - Update signal externally
+        value.set('1');
+        spectator.fixture.detectChanges();
+
+        // Assert - Signal change reflected in component
+        expect(value()).toBe('1');
+        expect(spectator.element.textContent).toBe('Value: 1');
+
+        // Act - Update component internally
+        spectator.component.value = '2';
+        spectator.component.valueChange.emit('2');
+        spectator.fixture.detectChanges();
+
+        // Assert - Component change reflected in signal
+        expect(value()).toBe('2');
+        expect(spectator.element.textContent).toBe('Value: 2');
+      });
+    });
+
+    describe('Host Bindings', () => {
+      let spectator: SpectatorRouting<TestCompHost>;
+      const isChecked: WritableSignal<string | boolean> = signal('initial');
+
+      const createComponent = createRoutingFactory<TestCompHost>({
+        component: TestCompHost,
+        imports: [TestCompHost],
+        bindings: [inputBinding('isChecked', isChecked)],
+      });
+
+      beforeEach(() => (spectator = createComponent()));
+
+      it('should toggle the host checked class', () => {
+        // Act
+        isChecked.set(false);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(false);
+
+        // Act
+        isChecked.set(true);
+        spectator.fixture.detectChanges();
+
+        // Assert
+        expect(spectator.element.classList.contains('checked')).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
✅ fixes #728

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

TestBed `bindings` not supported. (Introduced in https://github.com/angular/angular/pull/62040)

## What is the new behavior?

Support for TestBed native `bindings` option. (`inputBinding`, `outputBinding`, `twoWayBinding`)

This makes it easier to test components by avoiding the need to create a wrapper component.

Native alternative for `setInput`, `output`, `props`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
